### PR TITLE
Spotlight logic fixed & corrections to edge cases that would remove ambient lighting fixed. Depth map debug mode added. Minor fixes to light component IMGUI window.

### DIFF
--- a/Engine/Engine/Include/Core/Object/Sphere.h
+++ b/Engine/Engine/Include/Core/Object/Sphere.h
@@ -12,6 +12,7 @@ namespace Engine {
         void render() override {}
 
 		Vec3<Length> getPosition() const { return position; }
+        Length getRadius() const { return radius; }
     private:
         Vec3<Length> position;
         Length radius;

--- a/Engine/Engine/Include/Graphics/Lights/SpotLight.h
+++ b/Engine/Engine/Include/Graphics/Lights/SpotLight.h
@@ -28,6 +28,7 @@ namespace Engine {
 				Debug::unitSlider<Angle, Degrees>("Cut Off", cutOff, degrees(-270.0f), degrees(180.0f));
 				Debug::unitSlider<Angle, Degrees>("Outer Cut Off", outerCutOff, degrees(0.0f), degrees(90.0f));
 				Debug::unitSlider("Ambient Strength", ambientStrength, unitless(0.0f), unitless(10.0f));
+				ImGui::SliderFloat3("Direction", &direction.asDefaultUnits().x, -1.0f, 1.0f);
 				ImGui::SliderFloat3("Position", &position.asDefaultUnits().x, -100.0f, 100.0f);
 				ImGui::End();
 				});

--- a/Engine/Engine/Source/Graphics/Renderer.cpp
+++ b/Engine/Engine/Source/Graphics/Renderer.cpp
@@ -37,6 +37,8 @@ namespace {
 
 	Engine::Length nearPlane = Engine::meters(1.0f);
 	Engine::Length farPlane = Engine::meters(100.f);
+
+	bool depthMapDebug = false;
 }
 
 void Engine::Renderer::Group::addRenderComponent(const std::shared_ptr<RenderComponent>& renderComponent) {
@@ -181,6 +183,7 @@ void Engine::Renderer::initialize() {
 	lightingShader.setInt("gPosition", 0);
 	lightingShader.setInt("gNormal", 1);
 	lightingShader.setInt("gAlbedoSpec", 2);
+	lightingShader.setBool("depthMapDebug", depthMapDebug);
 
 	shadowShader.createShaderProgram(shaderPath + "shadow.vert", shaderPath + "shadow.frag");
 
@@ -382,7 +385,9 @@ glm::mat4 calculateLightSpaceMatrix(const std::shared_ptr<Engine::Light>& light)
 	case Engine::LightType::Directional: {
 		const glm::vec3 lightDirection = light->getRenderQueueEntry().shaderEntry.direction;
 		const glm::vec3 lightPos = -lightDirection * 10.0f;
-		const glm::mat4 lightProjection = glm::ortho(-10.0f, 10.0f, -10.0f, 10.0f, nearPlane.as<Engine::Meters>(), farPlane.as<Engine::Meters>());
+
+		//Set Orthographic projection using the size/corners of the arena
+		const glm::mat4 lightProjection = glm::ortho(-1000.0f, 1000.0f, -1000.0f, 1000.0f, nearPlane.as<Engine::Meters>(), farPlane.as<Engine::Meters>());
 		const glm::mat4 lightView = lookAt(lightPos, lightPos + lightDirection, ensureNonCollinearUp(lightDirection, glm::vec3(0.0f, 1.0f, 0.0f)));
 		return lightProjection * lightView;
 	}

--- a/Engine/Resources/Shaders/lighting_pass.frag
+++ b/Engine/Resources/Shaders/lighting_pass.frag
@@ -35,6 +35,8 @@ layout(std140, binding = 26) buffer Lights {
 
 layout(location = 27) uniform vec3 viewPos;
 
+uniform bool depthMapDebug;
+
 // Shadow calculation function
 float calculateShadow(vec4 FragPosLightSpace, sampler2D shadowMap, vec3 lightDir, vec3 fragToLight, float innerCutOff, float outerCutOff) {
     vec3 projCoords = FragPosLightSpace.xyz / FragPosLightSpace.w;
@@ -63,6 +65,12 @@ float calculateShadow(vec4 FragPosLightSpace, sampler2D shadowMap, vec3 lightDir
 }
 
 void main() {
+    if (depthMapDebug) {
+        float depthValue = texture(shadowMaps[0], TexCoords).r;
+        FragColor = vec4(vec3(depthValue), 1.0);
+        return;
+    }
+
     vec3 FragPos = texture(gPosition, TexCoords).rgb;
     vec3 Normal = texture(gNormal, TexCoords).rgb;
     Normal = normalize(Normal);

--- a/Game/Game/Source/SphereLight.cpp
+++ b/Game/Game/Source/SphereLight.cpp
@@ -4,7 +4,7 @@ void Game::SphereLightHook::initialize() {
     const auto lightSourceComponent = std::make_shared<Engine::LightSourceComponent>(owner->getId().lock().get());
 
     lightSourceComponent->addLight(std::make_shared<Engine::SpotLight>(
-        owner->getPosition(), Engine::Vec3(0.0f, -1.0f, 0.0f), Engine::Vec3(1.0f, 1.0f, 1.0f), Engine::unitless(1.0f), Engine::unitless(1.0f), 0.09f, 0.032f, Engine::degrees(45), Engine::degrees(65.f), Engine::unitless(0.1f)
+        owner->getPosition() + Engine::Vec3<Engine::Length>(0.f, -(owner->getRadius() + Engine::meters(2)), 0.f), Engine::Vec3(0.0f, -1.0f, 0.0f), Engine::Vec3(1.0f, 1.0f, 1.0f), Engine::unitless(1.0f), Engine::unitless(1.0f), 0.09f, 0.032f, Engine::degrees(45), Engine::degrees(65.f), Engine::unitless(0.1f)
         ));
 
     /*lightSourceComponent->addLight(std::make_shared<Engine::PointLight>(


### PR DESCRIPTION
Main issue: depth map is clearly not being generated correctly. Projection parameters are right, but the issue lies somewhere else.

Fixes to spotlights and some lighting pass logic that would remove ambient lighting. Depth map debug mode added to Renderer.cpp; it is clearly generateing incorrectly for an unkown reason. Already troubleshooted:

Light Space Matrix, lookAt() function, shadow calculations in fragment shader.
