### PR TITLE
Lead CEO/dev/intern has fulfilled his Destiny 2 and guardianly protected the Last City of shadow maps by adjusting near and far plane values. Shadows now work, with some artifacts to be dealt with.

### DIFF
--- a/Engine/Engine/Include/Graphics/Lights/DirectionalLight.h
+++ b/Engine/Engine/Include/Graphics/Lights/DirectionalLight.h
@@ -14,9 +14,9 @@ namespace Engine {
 		Vec3<> direction;
 		Unitless ambientStrength;
 
-		void showDebugMenu() override {
-			Debug::addImguiCallback([this] {
-				ImGui::Begin("Directional Light");
+		void showDebugMenu(const std::shared_ptr<ID>& lightID) override {
+			Debug::addImguiCallback([this, lightID] {
+				ImGui::Begin(std::string("Directional Light " + lightID->tag).c_str());
 				Debug::unitSlider("Intensity", intensity, unitless(0.0f), unitless(100.0f));
 				Debug::unitSlider("Ambient Strength", ambientStrength, unitless(0.0f), unitless(10.0f));
 				ImGui::SliderFloat3("Direction", &direction.asDefaultUnits().x, -1.0f, 1.0f);

--- a/Engine/Engine/Include/Graphics/Lights/Light.h
+++ b/Engine/Engine/Include/Graphics/Lights/Light.h
@@ -52,7 +52,7 @@ namespace Engine {
 		Light() = default;
 		virtual ~Light() = default;
 		virtual LightRenderQueueEntry getRenderQueueEntry() const = 0;
-        virtual void showDebugMenu() = 0;
+        virtual void showDebugMenu(const std::shared_ptr<ID>& lightID) = 0;
 
 		LightType getType() const { return type; }
 	protected:

--- a/Engine/Engine/Include/Graphics/Lights/PointLight.h
+++ b/Engine/Engine/Include/Graphics/Lights/PointLight.h
@@ -17,9 +17,9 @@ namespace Engine {
 		Unitless quadratic;
 		Unitless ambientStrength;
 
-		void showDebugMenu() override {
-			Debug::addImguiCallback([this] {
-				ImGui::Begin("Point Light");
+		void showDebugMenu(const std::shared_ptr<ID>& lightID) override {
+			Debug::addImguiCallback([this, lightID] {
+				ImGui::Begin(std::string("Point Light " + lightID->tag).c_str());
 				ImGui::ColorEdit3("Color", &color.asDefaultUnits().x);
 				Debug::unitSlider("Intensity", intensity, unitless(0.0f), unitless(100.0f));
 				Debug::unitSlider("Constant", constant, unitless(0.0f), unitless(1.0f));

--- a/Engine/Engine/Include/Graphics/Lights/SpotLight.h
+++ b/Engine/Engine/Include/Graphics/Lights/SpotLight.h
@@ -18,9 +18,9 @@ namespace Engine {
 		Vec3<> direction;
 		Unitless ambientStrength;
 
-		void showDebugMenu() override {
-			Debug::addImguiCallback([this] {
-				ImGui::Begin("Spot Light");
+		void showDebugMenu(const std::shared_ptr<ID>& lightID) override {
+			Debug::addImguiCallback([this, lightID] {
+				ImGui::Begin(std::string("Spot Light " + lightID->tag).c_str());
 				Debug::unitSlider("Intensity", intensity, unitless(0.0f), unitless(1000.0f));
 				Debug::unitSlider("Constant", constant, unitless(0.0f), unitless(1.0f));
 				Debug::unitSlider("Linear", linear, unitless(0.0f), unitless(1.0f));

--- a/Engine/Engine/Source/Graphics/Renderer.cpp
+++ b/Engine/Engine/Source/Graphics/Renderer.cpp
@@ -35,8 +35,8 @@ namespace {
 	GLsizei shadowWidth = 2048;
 	GLsizei shadowHeight = 2048;
 
-	Engine::Length nearPlane = Engine::meters(1.0f);
-	Engine::Length farPlane = Engine::meters(100.f);
+	Engine::Length nearPlane = Engine::meters(10.0f);
+	Engine::Length farPlane = Engine::meters(1000.f);
 
 	bool depthMapDebug = false;
 }
@@ -336,12 +336,11 @@ void renderLightingPass(const std::vector<Engine::LightShaderEntry>& lightData, 
 	glEnable(GL_DEPTH_TEST);  // Re-enable depth testing after the lighting pass
 }
 
-void renderShadowPass(const std::vector<std::weak_ptr<Engine::RenderComponent>>& renderComponents, const glm::mat4& lightSpaceMatrix, const GLuint depthMap) {
+void renderShadowPass(const std::vector<std::weak_ptr<Engine::RenderComponent>>& renderComponents, const glm::mat4& lightSpaceMatrix, const GLuint depthMapFBO) {
 	shadowShader.setMat4("lightSpaceMatrix", lightSpaceMatrix);
 
-	glEnable(GL_DEPTH_TEST);
 	glViewport(0, 0, shadowWidth, shadowHeight);
-	glBindFramebuffer(GL_FRAMEBUFFER, depthMap);
+	glBindFramebuffer(GL_FRAMEBUFFER, depthMapFBO);
 	glClear(GL_DEPTH_BUFFER_BIT);
 
 	for (const auto& renderComponent : renderComponents) {
@@ -416,8 +415,8 @@ void Engine::Renderer::renderObjects(Group& group) {
 
 	Debug::addImguiCallback([] {
 		ImGui::Begin("Near/Far Plane");
-		Debug::unitSlider<Length, Meters>("Near Plane", nearPlane, meters(0.1f), meters(10.0f));
-		Debug::unitSlider<Length, Meters>("Far Plane", farPlane, meters(10.0f), meters(1000.0f));
+		Debug::unitSlider<Length, Meters>("Near Plane", nearPlane, meters(0.1f), meters(100.0f));
+		Debug::unitSlider<Length, Meters>("Far Plane", farPlane, meters(10.0f), meters(10000.0f));
 		ImGui::End();
 		});
 

--- a/Engine/Resources/Shaders/LightShaders.json
+++ b/Engine/Resources/Shaders/LightShaders.json
@@ -3,6 +3,9 @@
     "vertex": "lighting_pass.vert",
     "fragment": "lighting_pass.frag"
   },
+  "Geometry": {
+    "geometry": "geometry_pass.geom"
+  },
   "Emissive": {
     "vertex": "emissive.vert",
     "fragment": "emissive.frag"

--- a/Engine/Resources/Shaders/geometry_pass.geom
+++ b/Engine/Resources/Shaders/geometry_pass.geom
@@ -1,0 +1,22 @@
+#version 330 core
+layout (triangles) in;
+layout (triangle_strip, max_vertices=18) out;
+
+uniform mat4 shadowMatrices[6];
+
+out vec4 FragPos; // FragPos from GS (output per emitvertex)
+
+void main()
+{
+    for(int face = 0; face < 6; ++face)
+    {
+        gl_Layer = face; // built-in variable that specifies to which face we render.
+        for(int i = 0; i < 3; ++i) // for each triangle vertex
+        {
+            FragPos = gl_in[i].gl_Position;
+            gl_Position = shadowMatrices[face] * FragPos;
+            EmitVertex();
+        }    
+        EndPrimitive();
+    }
+}  

--- a/Game/Game/Source/Game.cpp
+++ b/Game/Game/Source/Game.cpp
@@ -27,8 +27,8 @@ bool Game::initialize() {
 	box    = std::make_shared<Engine::Box>(Engine::Vec3<Engine::Meters>(20.f, -400.f, 20.f), Engine::Vec3<Engine::Meters>(20.f, 20.f, 20.f));
 	box2   = std::make_shared<Engine::Box>(Engine::Vec3<Engine::Meters>(-20.f, -400.f, 20.f), Engine::Vec3<Engine::Meters>(40.f, 40.f, 40.f));
 	sphere = std::make_shared<SphereLight>(Engine::Vec3<Engine::Meters>(0.f, -300.f, 0.f), Engine::meters(10.f));
-	sphere2 = std::make_shared<SphereLight>(Engine::Vec3<Engine::Meters>(0.f, 0.f, 0.f), Engine::meters(1.f));
-	sphere3 = std::make_shared<Engine::Sphere>(Engine::Vec3<Engine::Meters>(400.f, -400.f, 400.f), Engine::meters(10.f));
+	//sphere2 = std::make_shared<SphereLight>(Engine::Vec3<Engine::Meters>(0.f, 0.f, 0.f), Engine::meters(1.f));
+	sphere3 = std::make_shared<Engine::Sphere>(Engine::Vec3<Engine::Meters>(0.f, -400.f, 200.f), Engine::meters(10.f));
 
 	const auto scene1 = std::make_shared<Engine::Scene>();
 
@@ -37,7 +37,7 @@ bool Game::initialize() {
 	scene1->addObject(box);
 	scene1->addObject(box2);
 	scene1->addObject(sphere);
-	//scene1->addObject(sphere2);
+	scene1->addObject(sphere2);
 	scene1->addObject(sphere3);
 
 	Engine::sceneHandler.addScene(scene1, "Scene1");

--- a/Game/Game/Source/SphereLight.cpp
+++ b/Game/Game/Source/SphereLight.cpp
@@ -3,13 +3,13 @@
 void Game::SphereLightHook::initialize() {
     const auto lightSourceComponent = std::make_shared<Engine::LightSourceComponent>(owner->getId().lock().get());
 
-    lightSourceComponent->addLight(std::make_shared<Engine::SpotLight>(
+    /*lightSourceComponent->addLight(std::make_shared<Engine::SpotLight>(
         owner->getPosition() + Engine::Vec3<Engine::Length>(0.f, -(owner->getRadius() + Engine::meters(2)), 0.f), Engine::Vec3(0.0f, -1.0f, 0.0f), Engine::Vec3(1.0f, 1.0f, 1.0f), Engine::unitless(1.0f), Engine::unitless(1.0f), 0.09f, 0.032f, Engine::degrees(45), Engine::degrees(65.f), Engine::unitless(0.1f)
-        ));
+        ));*/
 
-    /*lightSourceComponent->addLight(std::make_shared<Engine::PointLight>(
-		glm::vec3(490.0f, 490.0f, 490.0f), glm::vec3(1.0f, 1.0f, 1.0f), 1.0f, 0.09f, 0.032f, 1.f, 0.1f
-    ));*/
+    lightSourceComponent->addLight(std::make_shared<Engine::PointLight>(
+		glm::vec3(1.0f, 1.0f, 1.0f), Engine::unitless(1.0f), glm::vec3(0.f, 0.f, 0.f), Engine::unitless(1.0f), Engine::unitless(0.09f), Engine::unitless(0.032f), Engine::unitless(0.1f)
+    ));
 
     owner->addComponent(lightSourceComponent);
 }
@@ -20,6 +20,6 @@ void Game::SphereLightHook::update() {
 
 void Game::SphereLightHook::render() {
     for (const auto& light : owner->getComponent<Engine::LightSourceComponent>()->getLights()) {
-        light->showDebugMenu();
+        light->showDebugMenu(owner->getId().lock());
     }
 }


### PR DESCRIPTION
"Whether we planned it or not, we've stumbled into a battle with shadow maps in our engine. So let's focus on taking down the root cause, one issue at a time. Near and far planes. From what I can tell, adjusting these critical values has brought the shadows back to life. They're not perfect yet—some artifacts remain—but with the right tweaks, we can break through these glitches, clean up the rendering, and finally bring balance to our scenes." - Commander Zavala