### PR TITLE
Add clang-p2996 toolchain bootstrap and CI build

### DIFF
--- a/.github/workflows/build-clang-p2996.yml
+++ b/.github/workflows/build-clang-p2996.yml
@@ -1,0 +1,96 @@
+name: build-clang-p2996
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. clang-p2996-v1)"
+        required: true
+      sha:
+        description: "clang-p2996 commit SHA to pin (leave blank for branch tip)"
+        required: false
+      branch:
+        description: "Source branch"
+        required: false
+        default: "p2996"
+      draft:
+        description: "Create release as draft"
+        required: false
+        default: "true"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 360
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
+      - name: Install Ninja
+        shell: pwsh
+        run: choco install ninja -y --no-progress
+
+      - name: Free runner disk space
+        shell: pwsh
+        run: |
+          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
+          Remove-Item -Recurse -Force -ErrorAction SilentlyContinue `
+            "$env:AGENT_TOOLSDIRECTORY\Ruby" , `
+            "$env:AGENT_TOOLSDIRECTORY\Go" , `
+            "$env:AGENT_TOOLSDIRECTORY\PyPy" , `
+            "$env:AGENT_TOOLSDIRECTORY\CodeQL"
+          Get-PSDrive -PSProvider FileSystem | Format-Table -AutoSize
+
+      - name: Build clang-p2996
+        shell: pwsh
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
+        run: |
+          $script_args = @("scripts/build_clang_p2996.py", "--branch", "${{ inputs.branch }}", "--link-jobs", "1")
+          if ("${{ inputs.sha }}") {
+            $script_args += @("--sha", "${{ inputs.sha }}")
+          }
+          python @script_args
+
+      - name: Compute artifact SHA256
+        id: hash
+        shell: pwsh
+        run: |
+          $hash = (Get-FileHash -Algorithm SHA256 dist/clang-p2996-windows-x64.zip).Hash.ToLower()
+          Write-Output "sha256=$hash" >> $env:GITHUB_OUTPUT
+          Write-Output "SHA256: $hash"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-p2996-windows-x64
+          path: dist/clang-p2996-windows-x64.zip
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: ${{ inputs.tag }}
+          draft: ${{ inputs.draft == 'true' }}
+          files: dist/clang-p2996-windows-x64.zip
+          body: |
+            Prebuilt `clang-p2996` toolchain for Windows x64.
+
+            - Branch: `${{ inputs.branch }}`
+            - SHA input: `${{ inputs.sha || 'branch tip' }}`
+            - SHA256: `${{ steps.hash.outputs.sha256 }}`
+
+            ## Install
+
+            ```
+            python scripts/install_clang_p2996.py --tag ${{ inputs.tag }} --sha256 ${{ steps.hash.outputs.sha256 }} --persist
+            ```

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ CMakeSettings.json
 Makefile
 /resources
 /Folder.DotSettings.user
+__pycache__/
+*.pyc
+/dist/
+/external/clang-p2996/
 *.ini
 /vc140.pdb
 /Engine/External/vcpkg

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -43,6 +43,45 @@
       "displayName": "x64 RelWithDebInfo",
       "inherits": "x64-base",
       "binaryDir": "${sourceDir}/out/build/x64-RelWithDebInfo"
+    },
+    {
+      "name": "x64-clang-p2996-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/Engine/External/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "CMAKE_C_COMPILER": "$env{CLANG_P2996_ROOT}/bin/clang-cl.exe",
+        "CMAKE_CXX_COMPILER": "$env{CLANG_P2996_ROOT}/bin/clang-cl.exe",
+        "CMAKE_CXX_FLAGS_INIT": "-std=c++2c -freflection-latest"
+      },
+      "environment": {
+        "PATH": "$env{CLANG_P2996_ROOT}/bin;$penv{PATH}"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "inheritEnvironments": [ "msvc_x64_x64" ]
+        }
+      },
+      "condition": {
+        "type": "notEquals",
+        "lhs": "$env{CLANG_P2996_ROOT}",
+        "rhs": ""
+      }
+    },
+    {
+      "name": "x64-clang-p2996-Debug",
+      "displayName": "x64 clang-p2996 Debug",
+      "inherits": "x64-clang-p2996-base",
+      "binaryDir": "${sourceDir}/out/build/x64-clang-p2996-Debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x64-clang-p2996-Release",
+      "displayName": "x64 clang-p2996 Release",
+      "inherits": "x64-clang-p2996-base",
+      "binaryDir": "${sourceDir}/out/build/x64-clang-p2996-Release",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
     }
   ],
   "buildPresets": [
@@ -60,6 +99,14 @@
       "name": "x64-RelWithDebInfo",
       "configurePreset": "x64-RelWithDebInfo",
       "configuration": "RelWithDebInfo"
+    },
+    {
+      "name": "x64-clang-p2996-Debug",
+      "configurePreset": "x64-clang-p2996-Debug"
+    },
+    {
+      "name": "x64-clang-p2996-Release",
+      "configurePreset": "x64-clang-p2996-Release"
     }
   ],
   "testPresets": []

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the following tools and ensure they are on your system `PATH`:
 - A compiler with C++20 module support
 - Vulkan SDK
 
-The `setup.py` script can bootstrap third‑party packages through vcpkg on Windows; vcpkg will look for:
+The `setup.py` script bootstraps third‑party packages through vcpkg on Windows. It installs:
 
 - [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)
 - [GLFW3](https://www.glfw.org/)
@@ -25,10 +25,45 @@ The `setup.py` script can bootstrap third‑party packages through vcpkg on Wind
 
 ## Quick Start
 
-1. Clone this repository.
-2. Configure with CMake to generate build files.
-3. Build the solution in your IDE or via the generated build scripts.
-4. Launch the editor to explore the sample scenes or integrate your own modules.
+```
+git clone <repo>
+python bootstrap.py --persist
+cmake --preset x64-Release
+cmake --build --preset x64-Release
+```
+
+`bootstrap.py` runs `setup.py` (vcpkg + dependencies) and then downloads the prebuilt `clang-p2996` toolchain. Skip a step with `--skip-deps` or `--skip-clang`. Pass `--skip-clang` if you only need the MSVC presets.
+
+## clang-p2996 Toolchain
+
+MSVC's module implementation is unreliable on this codebase, so we build with a prebuilt fork of Clang that also includes preview support for [P2996 reflection](https://github.com/bloomberg/clang-p2996).
+
+### As a teammate — just install
+
+```
+python scripts/install_clang_p2996.py --persist
+```
+
+This downloads the latest release zip to `%LOCALAPPDATA%\clang-p2996\<tag>` and sets `CLANG_P2996_ROOT`. Then use the `x64-clang-p2996-Debug` / `x64-clang-p2996-Release` CMake presets — they're hidden unless `CLANG_P2996_ROOT` is set, so they only appear once the install step has run.
+
+Pin a specific tag with `--tag clang-p2996-v1` and verify the artifact with `--sha256 <hash>` (both are printed in the GitHub release notes).
+
+### As a maintainer — cut a new release
+
+The `build-clang-p2996` GitHub Actions workflow does the full build + release upload. Trigger it manually from the Actions tab with:
+
+- `tag` — e.g. `clang-p2996-v2`
+- `sha` — clang-p2996 commit SHA to pin (leave blank for branch tip, but **pinning is strongly recommended**)
+
+The workflow produces a Windows x64 zip, computes its SHA256, and creates a draft release. Publish it after a sanity check, then bump `DEFAULT_TAG` in `scripts/install_clang_p2996.py` so `bootstrap.py` picks up the new release by default.
+
+To build locally instead of on CI (e.g. on your dev box — ~5x faster than a free GH runner), run from an **x64 Native Tools Command Prompt**:
+
+```
+python scripts/build_clang_p2996.py --sha <commit>
+```
+
+Expect 30–90 minutes and ~30 GB of disk.
 
 ## Code Style
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,40 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+
+
+def run_script(script, args):
+    result = subprocess.run([sys.executable, str(script), *args])
+    if result.returncode != 0:
+        raise SystemExit(f"{script.name} failed ({result.returncode})")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Full environment bootstrap: vcpkg deps + clang-p2996")
+    parser.add_argument("--skip-deps", action="store_true", help="Skip setup.py")
+    parser.add_argument("--skip-clang", action="store_true", help="Skip clang-p2996 install")
+    parser.add_argument("--update-vcpkg", action="store_true", help="Forwarded to setup.py")
+    parser.add_argument("--clang-tag", default=None, help="Forwarded to install_clang_p2996.py")
+    parser.add_argument("--persist", action="store_true", help="Persist CLANG_P2996_ROOT via setx")
+    args = parser.parse_args()
+
+    if not args.skip_deps:
+        deps_args = ["--update-vcpkg"] if args.update_vcpkg else []
+        run_script(REPO_ROOT / "setup.py", deps_args)
+
+    if not args.skip_clang:
+        clang_args = []
+        if args.clang_tag:
+            clang_args.extend(["--tag", args.clang_tag])
+        if args.persist:
+            clang_args.append("--persist")
+        run_script(REPO_ROOT / "scripts" / "install_clang_p2996.py", clang_args)
+
+    print("\nBootstrap complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_clang_p2996.py
+++ b/scripts/build_clang_p2996.py
@@ -1,0 +1,132 @@
+import argparse
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_URL = "https://github.com/bloomberg/clang-p2996.git"
+DEFAULT_BRANCH = "p2996"
+
+KEEP_BINARIES = {
+    "clang.exe",
+    "clang-cl.exe",
+    "clang++.exe",
+    "lld-link.exe",
+    "lld.exe",
+    "llvm-ar.exe",
+    "llvm-rc.exe",
+    "llvm-lib.exe",
+    "clang-scan-deps.exe",
+}
+
+
+def run(cmd, cwd=None):
+    display = " ".join(str(c) for c in cmd)
+    print(f"$ {display}")
+    result = subprocess.run(cmd, cwd=cwd)
+    if result.returncode != 0:
+        raise SystemExit(f"Command failed: {display}")
+
+
+def ensure_clone(src, branch, sha):
+    if not src.exists():
+        run(["git", "clone", "--branch", branch, REPO_URL, str(src)])
+    if sha:
+        run(["git", "fetch", "origin", sha], cwd=src)
+        run(["git", "checkout", sha], cwd=src)
+
+
+def current_sha(src):
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=src,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def configure(src, build, link_jobs):
+    build.mkdir(parents=True, exist_ok=True)
+    cmake_args = [
+        "cmake", "-S", str(src / "llvm"), "-B", str(build),
+        "-G", "Ninja",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DLLVM_ENABLE_PROJECTS=clang;lld",
+        "-DLLVM_TARGETS_TO_BUILD=X86",
+        "-DLLVM_ENABLE_ASSERTIONS=OFF",
+        "-DLLVM_USE_CRT_RELEASE=MT",
+    ]
+    if link_jobs is not None:
+        cmake_args.append(f"-DLLVM_PARALLEL_LINK_JOBS={link_jobs}")
+    run(cmake_args)
+
+
+def build_targets(build):
+    run(["cmake", "--build", str(build), "--target", "clang", "clang-cl", "lld-link"])
+
+
+def stage(build, dist):
+    if dist.exists():
+        shutil.rmtree(dist)
+    (dist / "bin").mkdir(parents=True)
+    bin_src = build / "bin"
+    for name in KEEP_BINARIES:
+        src = bin_src / name
+        if src.exists():
+            shutil.copy2(src, dist / "bin" / name)
+
+    lib_src = build / "lib" / "clang"
+    if lib_src.exists():
+        shutil.copytree(lib_src, dist / "lib" / "clang")
+
+
+def zip_dist(dist, out_zip):
+    if out_zip.exists():
+        out_zip.unlink()
+    out_zip.parent.mkdir(parents=True, exist_ok=True)
+    shutil.make_archive(str(out_zip.with_suffix("")), "zip", root_dir=dist)
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build and package bloomberg/clang-p2996 for distribution")
+    parser.add_argument("--src", type=Path, default=Path("external") / "clang-p2996")
+    parser.add_argument("--build", type=Path, default=Path("build") / "clang-p2996")
+    parser.add_argument("--dist", type=Path, default=Path("dist") / "clang-p2996")
+    parser.add_argument("--out", type=Path, default=Path("dist") / "clang-p2996-windows-x64.zip")
+    parser.add_argument("--branch", default=DEFAULT_BRANCH)
+    parser.add_argument("--sha", default=None, help="Pin clang-p2996 to a specific commit SHA")
+    parser.add_argument("--skip-build", action="store_true", help="Only stage and zip an existing build")
+    parser.add_argument(
+        "--link-jobs",
+        type=int,
+        default=None,
+        help="Set LLVM_PARALLEL_LINK_JOBS (limit concurrent linker procs to cap memory; useful on CI)",
+    )
+    args = parser.parse_args()
+
+    if not args.skip_build:
+        ensure_clone(args.src, args.branch, args.sha)
+        configure(args.src, args.build, args.link_jobs)
+        build_targets(args.build)
+
+    stage(args.build, args.dist)
+    zip_dist(args.dist, args.out)
+
+    print()
+    print(f"Source SHA: {current_sha(args.src)}")
+    print(f"Artifact:   {args.out}")
+    print(f"SHA256:     {sha256_of(args.out)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_clang_p2996.py
+++ b/scripts/install_clang_p2996.py
@@ -1,0 +1,90 @@
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+RELEASE_URL = "https://github.com/DhirenTheHeadlights/GSEngine/releases/download/{tag}/clang-p2996-windows-x64.zip"
+DEFAULT_TAG = "clang-p2996-v0"
+INSTALL_ROOT = Path(os.environ.get("LOCALAPPDATA", str(Path.home()))) / "clang-p2996"
+ENV_VAR = "CLANG_P2996_ROOT"
+
+
+def install_path(tag):
+    return INSTALL_ROOT / tag
+
+
+def already_installed(tag):
+    return (install_path(tag) / "bin" / "clang-cl.exe").exists()
+
+
+def download(url, dest):
+    print(f"Downloading {url}")
+    with urllib.request.urlopen(url) as response, open(dest, "wb") as out:
+        shutil.copyfileobj(response, out)
+
+
+def verify_sha256(path, expected):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    actual = h.hexdigest()
+    if actual.lower() != expected.lower():
+        raise SystemExit(f"SHA256 mismatch: got {actual}, expected {expected}")
+
+
+def extract(zip_path, dest):
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as z:
+        z.extractall(dest)
+
+
+def persist_env_var(name, value):
+    if os.name != "nt":
+        print(f"Add to your shell rc: export {name}={value}")
+        return
+    subprocess.run(["setx", name, str(value)], check=True)
+    print(f"Persisted {name} (effective in new shells)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download and install prebuilt clang-p2996 toolchain")
+    parser.add_argument("--tag", default=DEFAULT_TAG, help="Release tag to install")
+    parser.add_argument("--sha256", help="Expected SHA256 of the zip")
+    parser.add_argument("--persist", action="store_true", help=f"Persist {ENV_VAR} via setx")
+    parser.add_argument("--force", action="store_true", help="Reinstall even if already present")
+    parser.add_argument("--url", help="Override the release URL entirely")
+    args = parser.parse_args()
+
+    target = install_path(args.tag)
+    if already_installed(args.tag) and not args.force:
+        print(f"Already installed: {target}")
+    else:
+        url = args.url or RELEASE_URL.format(tag=args.tag)
+        with tempfile.TemporaryDirectory() as tmp:
+            zip_path = Path(tmp) / "toolchain.zip"
+            download(url, zip_path)
+            if args.sha256:
+                verify_sha256(zip_path, args.sha256)
+            extract(zip_path, target)
+        print(f"Installed: {target}")
+
+    if args.persist:
+        persist_env_var(ENV_VAR, target)
+    else:
+        print(f"\nTo use this toolchain:")
+        print(f"  set {ENV_VAR}={target}    (cmd)")
+        print(f"  $env:{ENV_VAR} = '{target}'  (PowerShell)")
+        print(f"Or re-run with --persist to set it permanently on Windows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -1,160 +1,87 @@
-import subprocess
+import argparse
 import os
-import shutil
-import urllib.request
-import winreg
+import subprocess
 import sys
+from pathlib import Path
 
-def run_command(command, cwd = None, capture_output = False):
-    try:
-        process = subprocess.Popen(
-            command, shell = True, cwd = cwd,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text = True
-        )
+REPO_ROOT = Path(__file__).resolve().parent
+VCPKG_DIR = REPO_ROOT / "Engine" / "External" / "vcpkg"
 
-        output_lines = []
-        for line in process.stdout:
-            print(line, end = "")  # Print live output
-            output_lines.append(line.strip())
+DEPENDENCIES = [
+    "msdfgen[core,extensions]:x64-windows",
+    "freetype[core]:x64-windows",
+    "glfw3:x64-windows",
+    "stb:x64-windows",
+    "miniaudio:x64-windows",
+    "shader-slang:x64-windows",
+    "tbb:x64-windows",
+]
 
-        process.wait()
 
-        if process.returncode != 0:
-            print(f"Error running command: {command}")
-            print(f"Exit Code: {process.returncode}")
-            for line in process.stderr:
-                print(line, end = "") 
-            hold_window()
-            return None  # Return None to indicate failure
+def run(cmd, cwd=None, capture=False):
+    display = " ".join(str(c) for c in cmd)
+    print(f"$ {display}")
+    result = subprocess.run(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.STDOUT if capture else None,
+        text=True,
+    )
+    if result.returncode != 0:
+        if capture and result.stdout:
+            print(result.stdout)
+        raise SystemExit(f"Command failed ({result.returncode}): {display}")
+    return result.stdout if capture else None
 
-        return "\n".join(output_lines) if capture_output else True  # Return full output if needed
-    except Exception as e:
-        print(f"Unexpected error running command: {command}\n{e}")
-        hold_window()
-        return None
 
-def path_exists(path):
-    return os.path.exists(path)
+def vcpkg_exe():
+    return VCPKG_DIR / ("vcpkg.exe" if os.name == "nt" else "vcpkg")
 
-def ensure_directory(directory):
-    if not os.path.exists(directory):
-        os.makedirs(directory)
 
-def delete_directory(directory):
-    if os.path.exists(directory):
-        shutil.rmtree(directory)
+def update_submodules():
+    if (REPO_ROOT / ".gitmodules").exists():
+        run(["git", "submodule", "update", "--init", "--recursive"], cwd=REPO_ROOT)
 
-def download_file(url, destination):
-    with urllib.request.urlopen(url) as response, open(destination, 'wb') as out_file:
-        shutil.copyfileobj(response, out_file)
 
-def get_downloads_folder():
-    try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER,
-                            r"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders") as key:
-            downloads_folder = winreg.QueryValueEx(key, "{374DE290-123F-4565-9164-39C4925E467B}")[0]
-            return downloads_folder
-    except Exception as e:
-        print(f"Error retrieving downloads folder: {e}")
-        hold_window()
-        return None
-        
-def upgrade_vcpkg_and_dependencies(vcpkg_path):
-    print("Resetting vcpkg repository to a clean state...")
-    if run_command("git reset --hard HEAD", cwd=vcpkg_path) is None:
-        print("Failed to reset vcpkg. Continuing with existing versions.")
-        return
-    
-    print("Updating vcpkg repository to get the latest package versions...")
-    if run_command("git pull origin master", cwd=vcpkg_path) is None:
-        print("Failed to update vcpkg. Continuing with existing versions.")
-        return
+def bootstrap_vcpkg(update_vcpkg):
+    if update_vcpkg:
+        run(["git", "pull", "origin", "master"], cwd=VCPKG_DIR)
+    bootstrap = VCPKG_DIR / ("bootstrap-vcpkg.bat" if os.name == "nt" else "bootstrap-vcpkg.sh")
+    run([str(bootstrap)], cwd=VCPKG_DIR)
 
-    print("\nChecking for outdated packages and upgrading them...")
-    upgrade_command = "vcpkg.exe upgrade --no-dry-run"
-    if run_command(upgrade_command, cwd=vcpkg_path) is None:
-        print("Package upgrade process failed.")
-        hold_window()
 
-def install_dependencies(vcpkg_path, dependencies):
-    print("Installing dependencies...")
-    install_command = "vcpkg.exe install --recurse --triplet x64-windows " + " ".join(dependencies)
-    if run_command(install_command, cwd=vcpkg_path) is None:
-        print("Dependency installation failed.")
-        hold_window()
-        return
+def install_deps():
+    run(
+        [str(vcpkg_exe()), "install", "--recurse", "--triplet", "x64-windows", *DEPENDENCIES],
+        cwd=VCPKG_DIR,
+    )
 
-def verify_dependencies(vcpkg_path, dependencies):
-    print("Verifying dependency installations...")
-    installed_output = run_command("vcpkg.exe list", cwd = vcpkg_path, capture_output = True)
-    if installed_output is None:
-        print("ERROR: Failed to check installed packages.")
-        hold_window()
-        return
 
-    installed_packages = installed_output.splitlines()
-    installed_set = {pkg.split(":")[0] for pkg in installed_packages if pkg}
+def verify_deps():
+    listed = run([str(vcpkg_exe()), "list"], cwd=VCPKG_DIR, capture=True) or ""
+    installed = {line.split(":")[0] for line in listed.splitlines() if line}
+    simple = [d.split("[")[0].split(":")[0] for d in DEPENDENCIES]
+    missing = [d for d in simple if d not in installed]
+    if missing:
+        raise SystemExit("Missing dependencies: " + ", ".join(missing))
+    print("All dependencies installed.")
 
-    simple_dependencies = [dep.split('[')[0] for dep in dependencies]
-
-    missing = [dep.split(":")[0] for dep in simple_dependencies if dep.split(":")[0] not in installed_set]
-
-    if not missing:
-        print("All dependencies are successfully installed!")
-    else:
-        print("ERROR: The following dependencies were not installed successfully:")
-        for dep in missing:
-            print(f" - {dep}")
-        hold_window()
-
-def hold_window():
-    input("Press Enter to exit...")
 
 def main():
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    print(current_dir)
+    parser = argparse.ArgumentParser(description="vcpkg bootstrap + engine dependencies")
+    parser.add_argument(
+        "--update-vcpkg",
+        action="store_true",
+        help="Pull latest vcpkg before bootstrapping (default: use the submodule-pinned SHA)",
+    )
+    args = parser.parse_args()
 
-    print("Checking for .gitmodules...")
-    if path_exists(os.path.join(current_dir, ".gitmodules")):
-        run_command("git submodule update --init --recursive", cwd = current_dir)
+    update_submodules()
+    bootstrap_vcpkg(args.update_vcpkg)
+    install_deps()
+    verify_deps()
 
-    vcpkg_path = os.path.join(current_dir, "Engine", "External", "vcpkg")   
-    print(f"vcpkg path is: {vcpkg_path}")
-
-    print("Updating vcpkg repository...")
-    if run_command("git pull origin master", cwd=vcpkg_path) is None:
-        print("Failed to update vcpkg. Aborting.")
-        hold_window()
-        return
-
-    print("Bootstrapping vcpkg to build the tool...")
-    if run_command("bootstrap-vcpkg.bat", cwd = vcpkg_path) is None:
-        print("Failed to bootstrap vcpkg. Aborting.")
-        hold_window()
-        return
-
-    print("\nChecking for outdated packages and upgrading them...")
-    upgrade_command = "vcpkg.exe upgrade --no-dry-run"
-    if run_command(upgrade_command, cwd=vcpkg_path) is None:
-        print("Package upgrade process failed.")
-
-    dependencies = [
-        "msdfgen[core,extensions]:x64-windows",
-        "freetype[core]:x64-windows",
-        "glfw3:x64-windows",
-        "stb:x64-windows",
-        "miniaudio:x64-windows",
-        "shader-slang:x64-windows",
-        "tbb:x64-windows",
-    ]
-
-    install_dependencies(vcpkg_path, dependencies)
-    verify_dependencies(vcpkg_path, dependencies)
 
 if __name__ == "__main__":
-    try:
-        main()
-    except Exception as e:
-        print(f"An unexpected error occurred: {e}")
-    finally:
-        input("Press Enter to exit...")
+    main()


### PR DESCRIPTION
## Summary
- One-stop `bootstrap.py` that runs `setup.py` (vcpkg + deps) and installs a prebuilt `clang-p2996` toolchain
- `scripts/install_clang_p2996.py` downloads the release zip, verifies SHA256, unpacks to `%LOCALAPPDATA%\clang-p2996\<tag>`, persists `CLANG_P2996_ROOT`
- `scripts/build_clang_p2996.py` builds and packages bloomberg/clang-p2996 for release (maintainer-only)
- GitHub Actions workflow `build-clang-p2996` runs the build on demand and creates a draft release
- New `x64-clang-p2996-{Debug,Release}` CMake presets (conditional on `CLANG_P2996_ROOT`) using `-std=c++2c -freflection-latest`
- `setup.py` cleaned up: dropped `hold_window()`, `shell=True`, dead helpers; vcpkg now stays on submodule-pinned SHA unless `--update-vcpkg` is passed

## Test plan
- [ ] Merge this PR so `workflow_dispatch` is visible on main
- [ ] Trigger `build-clang-p2996` with `tag=clang-p2996-v1`, leave `sha` blank (or pin a known-good SHA)
- [ ] Verify the draft release produced a valid zip, publish it
- [ ] Run `python bootstrap.py --persist` on a clean machine and confirm `CLANG_P2996_ROOT` is set and preset appears in VS
- [ ] Configure with `cmake --preset x64-clang-p2996-Release` and build the engine