### PR TITLE
Fix clang-p2996 build targets

### DIFF
--- a/scripts/build_clang_p2996.py
+++ b/scripts/build_clang_p2996.py
@@ -56,7 +56,6 @@ def configure(src, build, link_jobs):
         "-DLLVM_ENABLE_PROJECTS=clang;lld",
         "-DLLVM_TARGETS_TO_BUILD=X86",
         "-DLLVM_ENABLE_ASSERTIONS=OFF",
-        "-DLLVM_USE_CRT_RELEASE=MT",
     ]
     if link_jobs is not None:
         cmake_args.append(f"-DLLVM_PARALLEL_LINK_JOBS={link_jobs}")
@@ -64,7 +63,12 @@ def configure(src, build, link_jobs):
 
 
 def build_targets(build):
-    run(["cmake", "--build", str(build), "--target", "clang", "clang-cl", "lld-link"])
+    run([
+        "cmake", "--build", str(build),
+        "--target",
+        "clang", "lld",
+        "llvm-ar", "llvm-lib", "llvm-rc", "clang-scan-deps",
+    ])
 
 
 def stage(build, dist):


### PR DESCRIPTION
## Summary
- CI hit \`ninja: error: unknown target 'clang-cl'\` — \`clang-cl\` and \`lld-link\` aren't ninja targets, they're driver aliases of \`clang\` and \`lld\`. Build those instead.
- Drop unused \`LLVM_USE_CRT_RELEASE\` (removed from LLVM's CMake years ago — triggered an "unused variable" warning).
- Include \`llvm-ar\`, \`llvm-lib\`, \`llvm-rc\`, \`clang-scan-deps\` so the staged toolchain is complete for module-based builds.

## Test plan
- [ ] Merge
- [ ] Re-trigger \`build-clang-p2996\` workflow from the Actions tab
- [ ] Confirm the build reaches link stage without target-name errors