### PR TITLE
Disable DIA SDK in clang-p2996 build

### DIFF
--- a/scripts/build_clang_p2996.py
+++ b/scripts/build_clang_p2996.py
@@ -56,6 +56,7 @@ def configure(src, build, link_jobs):
         "-DLLVM_ENABLE_PROJECTS=clang;lld",
         "-DLLVM_TARGETS_TO_BUILD=X86",
         "-DLLVM_ENABLE_ASSERTIONS=OFF",
+        "-DLLVM_ENABLE_DIA_SDK=OFF",
     ]
     if link_jobs is not None:
         cmake_args.append(f"-DLLVM_PARALLEL_LINK_JOBS={link_jobs}")


### PR DESCRIPTION
## Summary
Local builds on VS installs that lack the optional ATL component were failing with:

\`\`\`
fatal error C1083: Cannot open include file: 'atlbase.h': No such file or directory
\`\`\`

LLVM's DIA-backed PDB reader requires ATL, but the \`clang\`/\`lld\` we're shipping don't need DIA at all (LLVM has its own native PDB reader). Disabling \`LLVM_ENABLE_DIA_SDK\` makes the build work regardless of ATL presence and also marginally faster.

## Test plan
- [ ] Merge
- [ ] Re-trigger \`build-clang-p2996\` workflow (also applies — GH runners don't have ATL)
- [ ] Local rebuild after wiping \`build/clang-p2996/\` succeeds through the PDB step