### PR TITLE
gpu: drive frame pacing from VK_EXT_present_timing feedback

### DIFF
--- a/Engine/Engine/Import/Gpu.cppm
+++ b/Engine/Engine/Import/Gpu.cppm
@@ -5,6 +5,7 @@ export import :sync_token;
 export import :gpu_task;
 export import :device;
 export import :swap_chain;
+export import :present_pacer;
 export import :frame;
 export import :transient_pool;
 export import :render_graph;

--- a/Engine/Engine/Source/Gpu/Device/Device.cppm
+++ b/Engine/Engine/Source/Gpu/Device/Device.cppm
@@ -162,11 +162,9 @@ export namespace gse::gpu {
 		) const -> gpu::handle<gpu::fence>;
 
 		[[nodiscard]]
-		auto swapchain_wait_for_present(
-			gpu::swap_chain_handle swapchain,
-			std::uint64_t present_id,
-			std::uint64_t timeout_ns = std::numeric_limits<std::uint64_t>::max()
-		) const -> result;
+		auto swapchain_past_presentation_timing(
+			gpu::swap_chain_handle swapchain
+		) const -> std::vector<past_present_timing>;
 
 		[[nodiscard]]
 		auto create_blas(
@@ -466,8 +464,8 @@ auto gse::gpu::device::swapchain_release_fence(const gpu::swap_chain_handle swap
 	return m_device_config.swapchain_release_fence(swapchain, image_index);
 }
 
-auto gse::gpu::device::swapchain_wait_for_present(const gpu::swap_chain_handle swapchain, const std::uint64_t present_id, const std::uint64_t timeout_ns) const -> result {
-	return m_device_config.swapchain_wait_for_present(swapchain, present_id, timeout_ns);
+auto gse::gpu::device::swapchain_past_presentation_timing(const gpu::swap_chain_handle swapchain) const -> std::vector<past_present_timing> {
+	return m_device_config.swapchain_past_presentation_timing(swapchain);
 }
 
 auto gse::gpu::device::create_blas(const acceleration_structure_geometry& geometry, const std::uint32_t prim_count) -> blas {

--- a/Engine/Engine/Source/Gpu/Device/Frame.cpp
+++ b/Engine/Engine/Source/Gpu/Device/Frame.cpp
@@ -5,10 +5,12 @@ import std;
 import :frame;
 import :device;
 import :swap_chain;
+import :present_pacer;
 
 import gse.os;
 import gse.assert;
 import gse.diag;
+import gse.time;
 
 auto gse::gpu::frame::create(device& dev, swap_chain& sc) -> std::unique_ptr<frame> {
 	auto s = create_sync_objects(dev, sc);
@@ -83,18 +85,12 @@ auto gse::gpu::frame::begin(window::data& win) -> std::expected<frame_token, fra
 		}
 	}
 
-	const auto prior_present_id = m_present_ids_in_flight[m_current_frame];
-	if (prior_present_id != 0) {
-		trace::scope_guard sg{ trace_id<"begin_frame::wait_present">() };
-		const auto present_wait_result = m_swapchain->wait_for_present(prior_present_id);
-		if (present_wait_result == result::error_device_lost) {
-			m_device->report_device_lost(std::format("waitForPresentKHR (frame {})", m_current_frame));
-			return std::unexpected(frame_status::device_lost);
+	{
+		trace::scope_guard sg{ trace_id<"begin_frame::present_feedback">() };
+		m_pacer.observe(m_swapchain->past_presentation_timing(), m_swapchain->refresh_interval());
+		if (m_pacer.has_feedback()) {
+			system_clock::submit_display_interval(m_pacer.frame_delta());
 		}
-		assert(
-			present_wait_result == result::success || present_wait_result == result::suboptimal_khr || present_wait_result == result::error_out_of_date_khr,
-			"vkWaitForPresentKHR returned unexpected status"
-		);
 	}
 
 	{
@@ -294,7 +290,7 @@ auto gse::gpu::frame::end(window::data& win, std::span<const queue_submission> a
 	result present_result;
 	{
 		trace::scope_guard sg{ trace_id<"end_frame::present">() };
-		present_result = m_swapchain->present(render_finished_handle, m_image_index, present_id);
+		present_result = m_swapchain->present(render_finished_handle, m_image_index, present_id, m_pacer.relative_target());
 		if (present_result == result::error_device_lost) {
 			m_device->report_device_lost(std::format("presentKHR (frame {}, image {})", m_current_frame, m_image_index));
 		}

--- a/Engine/Engine/Source/Gpu/Device/Frame.cppm
+++ b/Engine/Engine/Source/Gpu/Device/Frame.cppm
@@ -5,6 +5,7 @@ import std;
 import :aliases;
 import :device;
 import :swap_chain;
+import :present_pacer;
 
 import gse.os;
 import gse.core;
@@ -75,5 +76,6 @@ export namespace gse::gpu {
 		swap_chain* m_swapchain;
 		std::uint64_t m_next_present_id = 1;
 		std::array<std::uint64_t, max_frames_in_flight> m_present_ids_in_flight{};
+		present_pacer m_pacer;
 	};
 }

--- a/Engine/Engine/Source/Gpu/Device/PresentPacer.cppm
+++ b/Engine/Engine/Source/Gpu/Device/PresentPacer.cppm
@@ -1,0 +1,75 @@
+export module gse.gpu:present_pacer;
+
+import std;
+
+import gse.gpu_backend;
+import gse.math;
+
+export namespace gse::gpu {
+	class present_pacer {
+	public:
+		auto observe(
+			std::span<const past_present_timing> samples,
+			time_t<std::uint64_t> refresh_interval
+		) -> void;
+
+		[[nodiscard]] auto has_feedback() const -> bool;
+
+		[[nodiscard]] auto frame_delta() const -> time;
+
+		[[nodiscard]] auto relative_target() const -> time_t<std::uint64_t>;
+
+	private:
+		std::uint64_t m_last_present_id = 0;
+		std::uint64_t m_last_first_pixel_out_ns = 0;
+		double m_smoothed_ns = 0.0;
+		std::uint64_t m_refresh_interval_ns = 0;
+		bool m_has_baseline = false;
+	};
+}
+
+auto gse::gpu::present_pacer::observe(const std::span<const past_present_timing> samples, const time_t<std::uint64_t> refresh_interval) -> void {
+	m_refresh_interval_ns = static_cast<std::uint64_t>(refresh_interval);
+
+	std::vector<std::pair<std::uint64_t, std::uint64_t>> points;
+	points.reserve(samples.size());
+	for (const auto& sample : samples) {
+		if (!sample.complete) {
+			continue;
+		}
+		const auto first_pixel_out = static_cast<std::uint64_t>(sample.first_pixel_out);
+		if (first_pixel_out != 0) {
+			points.emplace_back(sample.present_id, first_pixel_out);
+		}
+	}
+	std::ranges::sort(points);
+
+	for (const auto& [id, first_pixel_out] : points) {
+		if (m_has_baseline && id > m_last_present_id) {
+			const auto id_delta = id - m_last_present_id;
+			const auto time_delta = first_pixel_out - m_last_first_pixel_out_ns;
+			const double per_frame = static_cast<double>(time_delta) / static_cast<double>(id_delta);
+			constexpr double alpha = 0.1;
+			m_smoothed_ns = m_smoothed_ns == 0.0 ? per_frame : m_smoothed_ns * (1.0 - alpha) + per_frame * alpha;
+		}
+		if (!m_has_baseline || id > m_last_present_id) {
+			m_last_present_id = id;
+			m_last_first_pixel_out_ns = first_pixel_out;
+			m_has_baseline = true;
+		}
+	}
+}
+
+auto gse::gpu::present_pacer::has_feedback() const -> bool {
+	return m_smoothed_ns > 0.0;
+}
+
+auto gse::gpu::present_pacer::frame_delta() const -> time {
+	const auto interval_ns = m_smoothed_ns > 0.0 ? m_smoothed_ns : static_cast<double>(m_refresh_interval_ns);
+	return nanoseconds(interval_ns);
+}
+
+auto gse::gpu::present_pacer::relative_target() const -> time_t<std::uint64_t> {
+	const auto target_ns = m_smoothed_ns > 0.0 ? static_cast<std::uint64_t>(m_smoothed_ns) : m_refresh_interval_ns;
+	return time_t<std::uint64_t>(target_ns);
+}

--- a/Engine/Engine/Source/Gpu/Device/Swapchain.cppm
+++ b/Engine/Engine/Source/Gpu/Device/Swapchain.cppm
@@ -56,7 +56,8 @@ export namespace gse::gpu {
 		auto present(
 			handle<gpu::semaphore> wait_semaphore,
 			std::uint32_t image_index,
-			std::uint64_t present_id
+			std::uint64_t present_id,
+			time_t<std::uint64_t> relative_target
 		) -> result;
 
 		[[nodiscard]] auto release_fence(
@@ -70,10 +71,9 @@ export namespace gse::gpu {
 		) -> void;
 
 		[[nodiscard]]
-		auto wait_for_present(
-			std::uint64_t present_id,
-			std::uint64_t timeout_ns = std::numeric_limits<std::uint64_t>::max()
-		) const -> result;
+		auto past_presentation_timing() const -> std::vector<past_present_timing>;
+
+		[[nodiscard]] auto refresh_interval() const -> time_t<std::uint64_t>;
 
 		[[nodiscard]] auto depth_image(
 			this auto& self
@@ -158,21 +158,27 @@ auto gse::gpu::swap_chain::acquire(const handle<gpu::semaphore> wait_semaphore, 
 	return m_device->acquire_swapchain_image(m_info.handle, wait_semaphore, timeout_ns);
 }
 
-auto gse::gpu::swap_chain::present(const handle<gpu::semaphore> wait_semaphore, const std::uint32_t image_index, const std::uint64_t present_id) -> result {
+auto gse::gpu::swap_chain::present(const handle<gpu::semaphore> wait_semaphore, const std::uint32_t image_index, const std::uint64_t present_id, const time_t<std::uint64_t> relative_target) -> result {
 	reset_release_fence(image_index);
 
 	const auto swapchain_handle = m_info.handle;
 	const auto current_present_mode = m_info.present_mode;
 	const auto release_fence_handle = m_device->swapchain_release_fence(m_info.handle, image_index);
 
-	const present_info info{
+	present_info info{
 		.wait_semaphores = std::span(&wait_semaphore, 1),
 		.swapchains = std::span(&swapchain_handle, 1),
 		.image_indices = std::span(&image_index, 1),
 		.present_modes = std::span(&current_present_mode, 1),
 		.release_fences = std::span(&release_fence_handle, 1),
 		.present_ids = std::span(&present_id, 1),
+		.time_domain_id = m_info.time_domain_id,
 	};
+
+	if (m_info.time_domain_id != 0) {
+		info.target_present_times = std::span(&relative_target, 1);
+		info.present_stage_queries = present_stage_flags(present_stage_flag::image_first_pixel_out);
+	}
 
 	return m_device->present(info);
 }
@@ -189,8 +195,12 @@ auto gse::gpu::swap_chain::reset_release_fence(const std::uint32_t image_index) 
 	m_device->reset_swapchain_release_fence(m_info.handle, image_index);
 }
 
-auto gse::gpu::swap_chain::wait_for_present(const std::uint64_t present_id, const std::uint64_t timeout_ns) const -> result {
-	return m_device->swapchain_wait_for_present(m_info.handle, present_id, timeout_ns);
+auto gse::gpu::swap_chain::past_presentation_timing() const -> std::vector<past_present_timing> {
+	return m_device->swapchain_past_presentation_timing(m_info.handle);
+}
+
+auto gse::gpu::swap_chain::refresh_interval() const -> time_t<std::uint64_t> {
+	return m_info.refresh_interval;
 }
 
 auto gse::gpu::swap_chain::depth_image(this auto& self) -> auto& {

--- a/Engine/Engine/Source/GpuBackend/Enums.cppm
+++ b/Engine/Engine/Source/GpuBackend/Enums.cppm
@@ -275,6 +275,18 @@ export namespace gse::gpu {
 		fifo_relaxed,
 	};
 
+	enum class present_stage_flag : std::uint32_t {
+		queue_operations_end = 1u << 0,
+		request_dequeued = 1u << 1,
+		image_first_pixel_out = 1u << 2,
+		image_first_pixel_visible = 1u << 3,
+	};
+
+	using present_stage_flags = gse::flags<present_stage_flag>;
+	constexpr auto operator|(present_stage_flag a, present_stage_flag b) -> present_stage_flags {
+		return present_stage_flags(a) | b;
+	}
+
 	enum class load_op : std::uint8_t {
 		load,
 		clear,

--- a/Engine/Engine/Source/GpuBackend/Image.cppm
+++ b/Engine/Engine/Source/GpuBackend/Image.cppm
@@ -207,6 +207,10 @@ export namespace gse::gpu {
 		gse::gpu::present_mode present_mode = gse::gpu::present_mode::fifo;
 		std::vector<gpu::handle<image>> images;
 		std::vector<gpu::handle<gpu::image_view>> image_views;
+		bool present_timing_supported = false;
+		time_t<std::uint64_t> refresh_interval{};
+		time_t<std::uint64_t> refresh_duration{};
+		std::uint64_t time_domain_id = 0;
 	};
 }
 

--- a/Engine/Engine/Source/GpuBackend/Sync.cppm
+++ b/Engine/Engine/Source/GpuBackend/Sync.cppm
@@ -5,6 +5,8 @@ import std;
 import :core;
 import :enums;
 
+import gse.math;
+
 export namespace gse::gpu {
 	struct queue_progress {
 		queue_id queue;
@@ -46,5 +48,14 @@ export namespace gse::gpu {
 		std::span<const present_mode> present_modes;
 		std::span<const gpu::handle<gpu::fence>> release_fences;
 		std::span<const std::uint64_t> present_ids;
+		std::span<const time_t<std::uint64_t>> target_present_times;
+		present_stage_flags present_stage_queries;
+		std::uint64_t time_domain_id = 0;
+	};
+
+	struct past_present_timing {
+		std::uint64_t present_id = 0;
+		time_t<std::uint64_t> first_pixel_out{};
+		bool complete = false;
 	};
 }

--- a/Engine/Engine/Source/Time/SystemClock.cppm
+++ b/Engine/Engine/Source/Time/SystemClock.cppm
@@ -11,6 +11,10 @@ export namespace gse::system_clock {
 
 	auto update() -> void;
 
+	auto submit_display_interval(
+		internal_time dt
+	) -> void;
+
 	template <is_quantity Q = default_time>
 	auto dt() -> Q;
 
@@ -42,6 +46,7 @@ namespace gse::system_clock {
 	internal_time frame_rate_update_time{};
 	internal_time fixed_accumulator{};
 	std::optional<int> fixed_step_override;
+	std::optional<internal_time> external_display_interval;
 
 	constexpr internal_time fps_report_interval = seconds(1.0);
 	constexpr internal_time const_update_time = milliseconds(16.6667);
@@ -66,7 +71,14 @@ auto gse::system_clock::update() -> void {
 		return;
 	}
 
-	delta_time = gse::quantity_cast<internal_time>(dt_clock.reset<double>());
+	const auto wall_delta = gse::quantity_cast<internal_time>(dt_clock.reset<double>());
+	if (external_display_interval.has_value()) {
+		delta_time = *external_display_interval;
+		external_display_interval.reset();
+	}
+	else {
+		delta_time = wall_delta;
+	}
 	update_frame_rate(delta_time);
 
 	fixed_accumulator += std::min(delta_time, max_render_step);
@@ -118,6 +130,10 @@ auto gse::system_clock::fixed_steps_this_frame() -> int {
 
 auto gse::system_clock::set_fixed_step_override(const std::optional<int> steps) -> void {
 	fixed_step_override = steps;
+}
+
+auto gse::system_clock::submit_display_interval(const internal_time dt) -> void {
+	external_display_interval = dt;
 }
 
 auto gse::system_clock::fps() -> std::uint32_t {

--- a/Engine/Engine/Source/Vulkan/Device.cpp
+++ b/Engine/Engine/Source/Vulkan/Device.cpp
@@ -19,6 +19,7 @@ import vulkan;
 import gse.assert;
 import gse.core;
 import gse.log;
+import gse.math;
 
 namespace gse::vulkan {
 	template <typename Feat>
@@ -223,7 +224,7 @@ auto gse::vulkan::device::create_swap_chain(const vec2i framebuffer_size, const 
 	);
 
 	vk::SwapchainCreateInfoKHR create_info{
-		.flags = {},
+		.flags = vk::SwapchainCreateFlagBitsKHR::ePresentTimingEXT | vk::SwapchainCreateFlagBitsKHR::ePresentId2,
 		.surface = vk_surface,
 		.minImageCount = image_count,
 		.imageFormat = surface_format.format,
@@ -318,6 +319,64 @@ auto gse::vulkan::device::create_swap_chain(const vec2i framebuffer_size, const 
 		release_fences.push_back(std::move(fence));
 	}
 
+	const auto vk_device = *raii_device();
+	const auto vk_swapchain = *vk_swap_chain;
+
+	bool present_timing_supported = false;
+	{
+		const vk::SurfacePresentModeKHR timing_present_mode{
+			.presentMode = present_mode,
+		};
+		const vk::PhysicalDeviceSurfaceInfo2KHR timing_surface_info{
+			.pNext = &timing_present_mode,
+			.surface = vk_surface,
+		};
+		vk::PresentTimingSurfaceCapabilitiesEXT timing_caps{};
+		vk::SurfaceCapabilities2KHR timing_caps_chain{
+			.pNext = &timing_caps,
+		};
+		(void)vk_phys.getSurfaceCapabilities2KHR(&timing_surface_info, &timing_caps_chain);
+		present_timing_supported = timing_caps.presentTimingSupported == vk::True;
+	}
+	assert(present_timing_supported, "VK_EXT_present_timing is not supported on this surface");
+
+	const auto timing_queue_result = vk_device.setSwapchainPresentTimingQueueSizeEXT(vk_swapchain, 32);
+	assert(
+		timing_queue_result == vk::Result::eSuccess || timing_queue_result == vk::Result::eNotReady,
+		"failed to set swapchain present timing queue size: {}",
+		vk::to_string(timing_queue_result)
+	);
+
+	time_t<std::uint64_t> refresh_interval{};
+	time_t<std::uint64_t> refresh_duration{};
+	{
+		const auto [props_result, props] = vk_device.getSwapchainTimingPropertiesEXT(vk_swapchain);
+		if (props_result == vk::Result::eSuccess) {
+			refresh_interval = time_t<std::uint64_t>(props.first.refreshInterval);
+			refresh_duration = time_t<std::uint64_t>(props.first.refreshDuration);
+		}
+	}
+
+	std::uint64_t time_domain_id = 0;
+	{
+		vk::SwapchainTimeDomainPropertiesEXT domain_props{};
+		std::uint64_t domains_counter = 0;
+		(void)vk_device.getSwapchainTimeDomainPropertiesEXT(vk_swapchain, &domain_props, &domains_counter);
+		std::vector<vk::TimeDomainKHR> domains(domain_props.timeDomainCount);
+		std::vector<std::uint64_t> domain_ids(domain_props.timeDomainCount);
+		domain_props.pTimeDomains = domains.data();
+		domain_props.pTimeDomainIds = domain_ids.data();
+		(void)vk_device.getSwapchainTimeDomainPropertiesEXT(vk_swapchain, &domain_props, &domains_counter);
+		for (std::uint32_t i = 0; i < domain_props.timeDomainCount; ++i) {
+			if (domains[i] == vk::TimeDomainKHR::eSwapchainLocalEXT) {
+				time_domain_id = domain_ids[i];
+			}
+		}
+		if (time_domain_id == 0 && !domain_ids.empty()) {
+			time_domain_id = domain_ids[0];
+		}
+	}
+
 	const auto handle = std::bit_cast<gpu::swap_chain_handle>(*vk_swap_chain);
 
 	gpu::swap_chain_info info{
@@ -325,6 +384,10 @@ auto gse::vulkan::device::create_swap_chain(const vec2i framebuffer_size, const 
 		.extent = { extent.width, extent.height },
 		.format = from_vk(format),
 		.present_mode = from_vk(present_mode),
+		.present_timing_supported = present_timing_supported,
+		.refresh_interval = refresh_interval,
+		.refresh_duration = refresh_duration,
+		.time_domain_id = time_domain_id,
 	};
 	info.images.reserve(images.size());
 	for (const auto& img : images) {
@@ -379,12 +442,56 @@ auto gse::vulkan::device::swapchain_release_fence(const gpu::swap_chain_handle s
 	return std::bit_cast<gpu::handle<gpu::fence>>(*resources->release_fences[image_index]);
 }
 
-auto gse::vulkan::device::swapchain_wait_for_present(const gpu::swap_chain_handle swapchain, const std::uint64_t present_id, const std::uint64_t timeout_ns) const -> gpu::result {
+auto gse::vulkan::device::swapchain_past_presentation_timing(const gpu::swap_chain_handle swapchain) const -> std::vector<gpu::past_present_timing> {
 	const auto* resources = m_owned.find(swapchain);
 	if (!resources) {
-		return gpu::result::error_unknown;
+		return {};
 	}
-	return from_vk(resources->swapchain.waitForPresent(present_id, timeout_ns));
+
+	const auto vk_device = *raii_device();
+	const auto vk_swapchain = *resources->swapchain;
+	const vk::PastPresentationTimingInfoEXT info{
+		.swapchain = vk_swapchain,
+	};
+
+	constexpr std::uint32_t batch = 16;
+	constexpr std::uint32_t max_stages = 4;
+
+	std::vector<gpu::past_present_timing> out;
+	for (;;) {
+		std::array<vk::PastPresentationTimingEXT, batch> timings{};
+		std::array<vk::PresentStageTimeEXT, batch * max_stages> stages{};
+		for (std::uint32_t i = 0; i < batch; ++i) {
+			timings[i].presentStageCount = max_stages;
+			timings[i].pPresentStages = stages.data() + static_cast<std::size_t>(i) * max_stages;
+		}
+		vk::PastPresentationTimingPropertiesEXT props{
+			.presentationTimingCount = batch,
+			.pPresentationTimings = timings.data(),
+		};
+		const auto result = vk_device.getPastPresentationTimingEXT(&info, &props);
+		if (result != vk::Result::eSuccess && result != vk::Result::eIncomplete) {
+			break;
+		}
+		const auto got = props.presentationTimingCount;
+		for (std::uint32_t i = 0; i < got; ++i) {
+			const auto& timing = timings[i];
+			gpu::past_present_timing sample{
+				.present_id = timing.presentId,
+				.complete = timing.reportComplete == vk::True,
+			};
+			for (std::uint32_t s = 0; s < timing.presentStageCount; ++s) {
+				if (timing.pPresentStages[s].stage & vk::PresentStageFlagBitsEXT::eImageFirstPixelOut) {
+					sample.first_pixel_out = time_t<std::uint64_t>(timing.pPresentStages[s].time);
+				}
+			}
+			out.push_back(sample);
+		}
+		if (got == 0 || result == vk::Result::eSuccess) {
+			break;
+		}
+	}
+	return out;
 }
 
 auto gse::vulkan::pick_surface_format(const physical_device& physical_device, const gpu::surface surface) -> gpu::image_format {
@@ -535,8 +642,8 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 		vk::PhysicalDeviceUnifiedImageLayoutsFeaturesKHR,
 		vk::PhysicalDeviceHostImageCopyFeaturesEXT,
 		vk::PhysicalDeviceSwapchainMaintenance1FeaturesEXT,
-		vk::PhysicalDevicePresentIdFeaturesKHR,
-		vk::PhysicalDevicePresentWaitFeaturesKHR,
+		vk::PhysicalDevicePresentTimingFeaturesEXT,
+		vk::PhysicalDevicePresentId2FeaturesKHR,
 		vk::PhysicalDeviceDescriptorHeapFeaturesEXT,
 		vk::PhysicalDeviceShaderObjectFeaturesEXT,
 		vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT,
@@ -552,8 +659,8 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 	const auto& unified_layouts_query = feature_chain.get<vk::PhysicalDeviceUnifiedImageLayoutsFeaturesKHR>();
 	const auto& host_image_copy_query = feature_chain.get<vk::PhysicalDeviceHostImageCopyFeaturesEXT>();
 	const auto& swapchain_maintenance1_query = feature_chain.get<vk::PhysicalDeviceSwapchainMaintenance1FeaturesEXT>();
-	const auto& present_id_query = feature_chain.get<vk::PhysicalDevicePresentIdFeaturesKHR>();
-	const auto& present_wait_query = feature_chain.get<vk::PhysicalDevicePresentWaitFeaturesKHR>();
+	const auto& present_timing_query = feature_chain.get<vk::PhysicalDevicePresentTimingFeaturesEXT>();
+	const auto& present_id2_query = feature_chain.get<vk::PhysicalDevicePresentId2FeaturesKHR>();
 	const auto& descriptor_heap_query = feature_chain.get<vk::PhysicalDeviceDescriptorHeapFeaturesEXT>();
 	const auto& shader_object_query = feature_chain.get<vk::PhysicalDeviceShaderObjectFeaturesEXT>();
 	const auto& eds3_query = feature_chain.get<vk::PhysicalDeviceExtendedDynamicState3FeaturesEXT>();
@@ -586,12 +693,16 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 		"VK_EXT_swapchain_maintenance1 is required"
 	);
 	assert(
-		supports_extension(vk::KHRPresentIdExtensionName) && present_id_query.presentId,
-		"VK_KHR_present_id is required"
+		supports_extension(vk::EXTPresentTimingExtensionName) && present_timing_query.presentTiming && present_timing_query.presentAtRelativeTime,
+		"VK_EXT_present_timing with relative-time scheduling is required"
 	);
 	assert(
-		supports_extension(vk::KHRPresentWaitExtensionName) && present_wait_query.presentWait,
-		"VK_KHR_present_wait is required"
+		supports_extension(vk::KHRPresentId2ExtensionName) && present_id2_query.presentId2,
+		"VK_KHR_present_id2 is required"
+	);
+	assert(
+		supports_extension(vk::KHRCalibratedTimestampsExtensionName),
+		"VK_KHR_calibrated_timestamps is required"
 	);
 
 	vk::PhysicalDeviceMemoryPriorityFeaturesEXT memory_priority_features{
@@ -686,13 +797,14 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 		.pNext = &host_image_copy_features,
 		.swapchainMaintenance1 = vk::True,
 	};
-	vk::PhysicalDevicePresentIdFeaturesKHR present_id_features{
+	vk::PhysicalDevicePresentId2FeaturesKHR present_id2_features{
 		.pNext = &swapchain_maintenance1_features,
-		.presentId = vk::True,
+		.presentId2 = vk::True,
 	};
-	vk::PhysicalDevicePresentWaitFeaturesKHR present_wait_features{
-		.pNext = &present_id_features,
-		.presentWait = vk::True,
+	vk::PhysicalDevicePresentTimingFeaturesEXT present_timing_features{
+		.pNext = &present_id2_features,
+		.presentTiming = vk::True,
+		.presentAtRelativeTime = vk::True,
 	};
 
 	optional_feature<vk::PhysicalDeviceFaultFeaturesEXT> fault{
@@ -717,7 +829,7 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 		vk::KHRDynamicRenderingExtensionName,
 		vk::KHRMaintenance5ExtensionName,
 		vk::KHRMaintenance6ExtensionName,
-		vk::EXTCalibratedTimestampsExtensionName,
+		vk::KHRCalibratedTimestampsExtensionName,
 		vk::EXTPageableDeviceLocalMemoryExtensionName,
 		vk::EXTMemoryPriorityExtensionName,
 		vk::EXTMeshShaderExtensionName,
@@ -732,11 +844,11 @@ auto gse::vulkan::device::create(const instance& instance_data, device::settings
 		vk::KHRUnifiedImageLayoutsExtensionName,
 		vk::EXTHostImageCopyExtensionName,
 		vk::EXTSwapchainMaintenance1ExtensionName,
-		vk::KHRPresentIdExtensionName,
-		vk::KHRPresentWaitExtensionName,
+		vk::KHRPresentId2ExtensionName,
+		vk::EXTPresentTimingExtensionName,
 	};
 
-	void* chain_head = &present_wait_features;
+	void* chain_head = &present_timing_features;
 	auto process = [&](auto&... features) {
 		((chain_head = features.attach(chain_head)), ...);
 		(features.register_ext(device_extensions), ...);

--- a/Engine/Engine/Source/Vulkan/Device.cppm
+++ b/Engine/Engine/Source/Vulkan/Device.cppm
@@ -388,11 +388,9 @@ export namespace gse::vulkan {
 		) const -> gpu::handle<gpu::fence>;
 
 		[[nodiscard]]
-		auto swapchain_wait_for_present(
-			gpu::swap_chain_handle swapchain,
-			std::uint64_t present_id,
-			std::uint64_t timeout_ns = std::numeric_limits<std::uint64_t>::max()
-		) const -> gpu::result;
+		auto swapchain_past_presentation_timing(
+			gpu::swap_chain_handle swapchain
+		) const -> std::vector<gpu::past_present_timing>;
 
 		[[nodiscard]]
 		auto create_blas(

--- a/Engine/Engine/Source/Vulkan/Queues.cppm
+++ b/Engine/Engine/Source/Vulkan/Queues.cppm
@@ -11,6 +11,7 @@ import :physical_device;
 import gse.core;
 import gse.log;
 import gse.assert;
+import gse.math;
 
 export namespace gse::vulkan {
 	struct queue_family {
@@ -113,9 +114,11 @@ namespace gse::vulkan {
 		std::vector<vk::SwapchainKHR> swapchains;
 		std::vector<vk::PresentModeKHR> present_modes;
 		std::vector<vk::Fence> release_fences;
+		std::vector<vk::PresentTimingInfoEXT> timing_infos;
 		std::optional<vk::SwapchainPresentModeInfoEXT> mode_info;
 		std::optional<vk::SwapchainPresentFenceInfoEXT> fence_info;
-		std::optional<vk::PresentIdKHR> present_id_info;
+		std::optional<vk::PresentId2KHR> present_id_info;
+		std::optional<vk::PresentTimingsInfoEXT> timing_info;
 	};
 
 	auto build_vk_present_info(
@@ -202,12 +205,33 @@ auto gse::vulkan::build_vk_present_info(const gpu::present_info& info, present_s
 		pnext_head = &*scratch.fence_info;
 	}
 	if (!info.present_ids.empty()) {
-		scratch.present_id_info = vk::PresentIdKHR{
+		scratch.present_id_info = vk::PresentId2KHR{
 			.pNext = pnext_head,
 			.swapchainCount = static_cast<std::uint32_t>(info.present_ids.size()),
 			.pPresentIds = info.present_ids.data(),
 		};
 		pnext_head = &*scratch.present_id_info;
+	}
+	if (!info.target_present_times.empty()) {
+		const auto stage_queries = to_vk(info.present_stage_queries);
+		scratch.timing_infos.reserve(info.target_present_times.size());
+		for (std::size_t i = 0; i < info.target_present_times.size(); ++i) {
+			scratch.timing_infos.push_back(
+				vk::PresentTimingInfoEXT{
+					.flags = vk::PresentTimingInfoFlagBitsEXT::ePresentAtRelativeTime,
+					.targetTime = 0,
+					.timeDomainId = info.time_domain_id,
+					.presentStageQueries = stage_queries,
+					.targetTimeDomainPresentStage = {},
+				}
+			);
+		}
+		scratch.timing_info = vk::PresentTimingsInfoEXT{
+			.pNext = pnext_head,
+			.swapchainCount = static_cast<std::uint32_t>(scratch.timing_infos.size()),
+			.pTimingInfos = scratch.timing_infos.data(),
+		};
+		pnext_head = &*scratch.timing_info;
 	}
 
 	return vk::PresentInfoKHR{
@@ -313,5 +337,9 @@ auto gse::vulkan::queue::present(const gpu::present_info& info) -> gpu::result {
 	std::lock_guard lock(*m_mutex);
 	present_scratch scratch;
 	const auto vk_info = build_vk_present_info(info, scratch);
-	return from_vk(std::bit_cast<vk::Queue>(m_present).presentKHR(vk_info));
+	const auto vk_result = std::bit_cast<vk::Queue>(m_present).presentKHR(vk_info);
+	if (vk_result != vk::Result::eSuccess && vk_result != vk::Result::eSuboptimalKHR && vk_result != vk::Result::eErrorOutOfDateKHR) {
+		log::println(log::level::error, log::category::vulkan, "vkQueuePresentKHR returned {}", vk::to_string(vk_result));
+	}
+	return from_vk(vk_result);
 }

--- a/Engine/Engine/Source/Vulkan/Types.cppm
+++ b/Engine/Engine/Source/Vulkan/Types.cppm
@@ -163,6 +163,10 @@ export namespace gse::vulkan {
 		gpu::pipeline_statistic_flags fls
 	) -> vk::QueryPipelineStatisticFlags;
 
+	auto to_vk(
+		gpu::present_stage_flags fls
+	) -> vk::PresentStageFlagsEXT;
+
 	auto format_value(
 		gpu::image_format f
 	) -> gpu::image_format_value;
@@ -1068,6 +1072,23 @@ auto gse::vulkan::to_vk(const gpu::acceleration_structure_build_range_info& r) -
 		.firstVertex = r.first_vertex,
 		.transformOffset = r.transform_offset,
 	};
+}
+
+auto gse::vulkan::to_vk(const gpu::present_stage_flags fls) -> vk::PresentStageFlagsEXT {
+	vk::PresentStageFlagsEXT result{};
+	if (fls.test(gpu::present_stage_flag::queue_operations_end)) {
+		result |= vk::PresentStageFlagBitsEXT::eQueueOperationsEnd;
+	}
+	if (fls.test(gpu::present_stage_flag::request_dequeued)) {
+		result |= vk::PresentStageFlagBitsEXT::eRequestDequeued;
+	}
+	if (fls.test(gpu::present_stage_flag::image_first_pixel_out)) {
+		result |= vk::PresentStageFlagBitsEXT::eImageFirstPixelOut;
+	}
+	if (fls.test(gpu::present_stage_flag::image_first_pixel_visible)) {
+		result |= vk::PresentStageFlagBitsEXT::eImageFirstPixelVisible;
+	}
+	return result;
 }
 
 auto gse::vulkan::from_vk(const vk::Result r) -> gpu::result {


### PR DESCRIPTION
Replaces the `VK_KHR_present_id` / `present_wait` blocking pacer with **`VK_EXT_present_timing`**.

## What
- Device requires `VK_EXT_present_timing` + `VK_KHR_present_id2` + KHR calibrated timestamps.
- Swapchain opts in via the present-timing / present-id-2 create flags, sizes the timing-results queue, and selects a time domain.
- Present submits `VkPresentId2KHR` + a feedback-only `VkPresentTimingsInfoEXT` (`IMAGE_FIRST_PIXEL_OUT` stage query).
- New `present_pacer` drains past-presentation timing each frame and feeds the smoothed display interval to `system_clock` as the variable frame delta.
- Legacy `wait_for_present` plumbing removed.

## Notes
- NVIDIA-only for now: `VK_EXT_present_timing` is `EXT` and present only on proprietary Windows drivers; validated stable on RTX 5090 / driver 596.60.
- Present scheduling is **feedback-only** (no relative target) — a min-visibility target is redundant with FIFO and caused a throttle, so the display-driven `dt` is the pacing.
- Not included (left local): a `.vscode/settings.json` `VK_LAYER_PATH` Windows fix and a `Stacktrace.cppm` `<version>` include.