### PR TITLE
Production-grade logger overhaul: async, filtering, sinks, backtrace, rotation, fatal, color

### DIFF
--- a/Engine/Engine/Import/Assert.cpp
+++ b/Engine/Engine/Import/Assert.cpp
@@ -22,7 +22,6 @@ auto gse::assert_format_message(const std::source_location loc, const std::strin
 }
 
 auto gse::assert_fail(const std::string_view message) noexcept -> void {
-	log::println(log::level::error, log::category::general, "{}", message);
-	log::flush();
-	std::terminate();
+	log::println(log::level::fatal, log::category::general, "{}", message);
+	std::unreachable();
 }

--- a/Engine/Engine/Import/Assert.cpp
+++ b/Engine/Engine/Import/Assert.cpp
@@ -1,0 +1,28 @@
+module gse.assert;
+
+import std;
+
+import gse.log;
+import gse.stacktrace;
+
+auto gse::assert_format_message(const std::source_location loc, const std::string_view comment) -> std::string {
+	return std::format(
+		"[Assertion Failure]\n"
+		"File: {}\n"
+		"Line: {}\n"
+		"Function: {}\n"
+		"Comment: {}\n"
+		"Stack:\n{}",
+		loc.file_name(),
+		loc.line(),
+		loc.function_name(),
+		comment,
+		capture_stacktrace(2)
+	);
+}
+
+auto gse::assert_fail(const std::string_view message) noexcept -> void {
+	log::println(log::level::error, log::category::general, "{}", message);
+	log::flush();
+	std::terminate();
+}

--- a/Engine/Engine/Import/Assert.cppm
+++ b/Engine/Engine/Import/Assert.cppm
@@ -2,9 +2,6 @@ export module gse.assert;
 
 import std;
 
-import gse.log;
-import gse.stacktrace;
-
 export namespace gse {
 	template <typename... Args>
 	struct fmt_loc {
@@ -62,26 +59,4 @@ auto gse::assert(const bool condition, const std::source_location loc, std::form
 
 	const std::string comment = std::format(fmt, std::forward<Args>(args)...);
 	assert_fail(assert_format_message(loc, comment));
-}
-
-auto gse::assert_format_message(const std::source_location loc, const std::string_view comment) -> std::string {
-	return std::format(
-		"[Assertion Failure]\n"
-		"File: {}\n"
-		"Line: {}\n"
-		"Function: {}\n"
-		"Comment: {}\n"
-		"Stack:\n{}",
-		loc.file_name(),
-		loc.line(),
-		loc.function_name(),
-		comment,
-		capture_stacktrace(1)
-	);
-}
-
-auto gse::assert_fail(const std::string_view message) noexcept -> void {
-	log::println(log::level::error, log::category::general, "{}", message);
-	log::flush();
-	std::terminate();
 }

--- a/Engine/Engine/Import/Assert.cppm
+++ b/Engine/Engine/Import/Assert.cppm
@@ -36,7 +36,7 @@ namespace gse {
 		std::string_view comment
 	) -> std::string;
 
-	auto assert_fail(
+	[[noreturn]] auto assert_fail(
 		std::string_view message
 	) noexcept -> void;
 }

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -159,7 +159,7 @@ auto gse::log::current_thread_tag() -> std::uint64_t {
 }
 
 auto gse::log::should_flush(const level lvl) -> bool {
-	return lvl == level::error;
+	return lvl >= level::error;
 }
 
 auto gse::log::thread_display() -> std::string {
@@ -436,6 +436,27 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 	auto ts = timestamp_string();
 	auto thread = thread_display();
 	auto message = std::vformat(fmt, args);
+
+	if (lvl == level::fatal) {
+		flush();
+		std::lock_guard sink_lock(m_sink_mutex);
+		dump_backtrace_locked();
+		const record rec{
+			.lvl = lvl,
+			.cat = cat,
+			.timestamp = ts,
+			.thread = thread,
+			.prefix = extra_prefix,
+			.message = message,
+		};
+		for (auto& s : m_sinks) {
+			s->write(rec);
+		}
+		for (auto& s : m_sinks) {
+			s->flush();
+		}
+		std::terminate();
+	}
 
 	if (m_async.load(std::memory_order_acquire)) {
 		m_queue.enqueue(queued_record{

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -12,9 +12,54 @@ namespace gse::log {
 
 	auto current_thread_tag() -> std::uint64_t;
 
+	auto thread_display() -> std::string;
+
 	auto should_flush(
 		level lvl
 	) -> bool;
+
+	constexpr auto category_count = std::define_static_array(std::meta::enumerators_of(^^category)).size();
+
+	constexpr std::size_t no_thread_index = std::numeric_limits<std::size_t>::max();
+
+	std::array<std::atomic<level>, category_count> g_category_levels;
+
+	thread_local thread_role t_thread_role = thread_role::unknown;
+
+	thread_local std::size_t t_thread_index = no_thread_index;
+
+	class console_sink : public sink {
+	public:
+		auto write(
+			const record& rec
+		) -> void override;
+
+		auto write_raw(
+			std::string_view text
+		) -> void override;
+
+		auto flush() -> void override;
+	};
+
+	class file_sink : public sink {
+	public:
+		explicit file_sink(
+			std::filesystem::path path
+		);
+
+		auto write(
+			const record& rec
+		) -> void override;
+
+		auto write_raw(
+			std::string_view text
+		) -> void override;
+
+		auto flush() -> void override;
+
+	private:
+		std::ofstream m_file;
+	};
 }
 
 auto gse::log::log_file_path() -> std::filesystem::path {
@@ -39,68 +84,177 @@ auto gse::log::should_flush(const level lvl) -> bool {
 	return lvl == level::error;
 }
 
-gse::log::logger::logger() {
-	std::error_code ec;
-	std::filesystem::create_directories(log_file_path().parent_path(), ec);
-	m_file.open(log_file_path(), std::ios::out | std::ios::trunc);
-	if (m_file.is_open()) {
-		const auto ts = timestamp_string();
-		std::println(m_file, "=== Log started at {} ===", ts);
-		std::println(std::cout, "=== Log started at {} ===", ts);
-		m_file.flush();
-		std::cout.flush();
+auto gse::log::thread_display() -> std::string {
+	if (t_thread_role == thread_role::unknown) {
+		return std::format("T{:016x}", current_thread_tag());
+	}
+	if (t_thread_index == no_thread_index) {
+		return std::format("{}", t_thread_role);
+	}
+	return std::format("{}-{}", t_thread_role, t_thread_index);
+}
+
+auto gse::log::set_level(const level min) -> void {
+	for (auto& slot : g_category_levels) {
+		slot.store(min, std::memory_order_relaxed);
 	}
 }
 
-gse::log::logger::~logger() {
-	const auto ts = timestamp_string();
-	if (m_file.is_open()) {
-		std::println(m_file, "=== Log ended at {} ===", ts);
-		m_file.flush();
-		m_file.close();
-	}
-	std::println(std::cout, "=== Log ended at {} ===", ts);
-	std::cout.flush();
+auto gse::log::set_level(const category cat, const level min) -> void {
+	g_category_levels[static_cast<std::size_t>(cat)].store(min, std::memory_order_relaxed);
 }
 
-auto gse::log::logger::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
-	std::lock_guard lock(m_mutex);
-	const bool flush_now = should_flush(lvl);
-	auto& console = flush_now ? static_cast<std::ostream&>(std::cerr) : static_cast<std::ostream&>(std::cout);
+auto gse::log::level_of(const category cat) -> level {
+	return g_category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
+}
 
-	const auto ts = timestamp_string();
-	const auto thread = current_thread_tag();
+auto gse::log::enabled(const level lvl, const category cat) -> bool {
+	return lvl >= g_category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
+}
 
-	std::print(console, "[{}][{}][{}][T{:016x}] {}", ts, lvl, cat, thread, extra_prefix);
-	std::vprint_unicode(console, fmt, args);
-	std::print(console, "\n");
+auto gse::log::name_thread(const thread_role role) -> void {
+	t_thread_role = role;
+	t_thread_index = no_thread_index;
+}
 
-	if (m_file.is_open()) {
-		std::print(m_file, "[{}][{}][{}][T{:016x}] {}", ts, lvl, cat, thread, extra_prefix);
-		std::vprint_unicode(m_file, fmt, args);
-		std::print(m_file, "\n");
+auto gse::log::name_thread(const thread_role role, const std::size_t index) -> void {
+	t_thread_role = role;
+	t_thread_index = index;
+}
+
+gse::log::sampler::sampler(const std::uint64_t every) : m_mode(mode::count), m_every(every == 0 ? 1 : every) {}
+
+gse::log::sampler::sampler(const std::chrono::steady_clock::duration min_interval) : m_mode(mode::interval), m_interval(min_interval), m_last((std::chrono::steady_clock::now() - min_interval).time_since_epoch().count()) {}
+
+auto gse::log::sampler::tick() -> bool {
+	if (m_mode == mode::count) {
+		const auto n = m_count.fetch_add(1, std::memory_order_relaxed);
+		return n % m_every == 0;
 	}
 
-	if (flush_now) {
-		console.flush();
-		if (m_file.is_open()) {
-			m_file.flush();
+	const auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+	auto last = m_last.load(std::memory_order_relaxed);
+	for (;;) {
+		if (now - last < m_interval.count()) {
+			return false;
+		}
+		if (m_last.compare_exchange_weak(last, now, std::memory_order_relaxed)) {
+			return true;
 		}
 	}
 }
 
-auto gse::log::logger::flush() -> void {
-	std::lock_guard lock(m_mutex);
+auto gse::log::format_line(const record& rec) -> std::string {
+	return std::format("[{}][{}][{}][{}] {}{}", rec.timestamp, rec.lvl, rec.cat, rec.thread, rec.prefix, rec.message);
+}
+
+gse::log::sink::~sink() = default;
+
+auto gse::log::console_sink::write(const record& rec) -> void {
+	auto& os = should_flush(rec.lvl) ? static_cast<std::ostream&>(std::cerr) : static_cast<std::ostream&>(std::cout);
+	std::print(os, "{}\n", format_line(rec));
+}
+
+auto gse::log::console_sink::write_raw(const std::string_view text) -> void {
+	std::print(std::cout, "{}\n", text);
+}
+
+auto gse::log::console_sink::flush() -> void {
 	std::cout.flush();
 	std::cerr.flush();
+}
+
+gse::log::file_sink::file_sink(const std::filesystem::path path) {
+	std::error_code ec;
+	std::filesystem::create_directories(path.parent_path(), ec);
+	m_file.open(path, std::ios::out | std::ios::trunc);
+}
+
+auto gse::log::file_sink::write(const record& rec) -> void {
+	if (m_file.is_open()) {
+		std::print(m_file, "{}\n", format_line(rec));
+	}
+}
+
+auto gse::log::file_sink::write_raw(const std::string_view text) -> void {
+	if (m_file.is_open()) {
+		std::print(m_file, "{}\n", text);
+	}
+}
+
+auto gse::log::file_sink::flush() -> void {
 	if (m_file.is_open()) {
 		m_file.flush();
+	}
+}
+
+gse::log::logger::logger() {
+	m_sinks.push_back(std::make_unique<console_sink>());
+	m_sinks.push_back(std::make_unique<file_sink>(log_file_path()));
+
+	const auto marker = std::format("=== Log started at {} ===", timestamp_string());
+	for (auto& s : m_sinks) {
+		s->write_raw(marker);
+		s->flush();
+	}
+}
+
+gse::log::logger::~logger() {
+	const auto marker = std::format("=== Log ended at {} ===", timestamp_string());
+	for (auto& s : m_sinks) {
+		s->write_raw(marker);
+		s->flush();
+	}
+}
+
+auto gse::log::logger::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
+	std::lock_guard lock(m_mutex);
+
+	const auto ts = timestamp_string();
+	const auto thread = thread_display();
+	const auto message = std::vformat(fmt, args);
+
+	const record rec{
+		.lvl = lvl,
+		.cat = cat,
+		.timestamp = ts,
+		.thread = thread,
+		.prefix = extra_prefix,
+		.message = message,
+	};
+
+	for (auto& s : m_sinks) {
+		if (lvl >= s->min_level.load(std::memory_order_relaxed)) {
+			s->write(rec);
+		}
+	}
+
+	if (should_flush(lvl)) {
+		for (auto& s : m_sinks) {
+			s->flush();
+		}
+	}
+}
+
+auto gse::log::logger::add_sink(std::unique_ptr<sink> s) -> sink* {
+	std::lock_guard lock(m_mutex);
+	return m_sinks.emplace_back(std::move(s)).get();
+}
+
+auto gse::log::logger::flush() -> void {
+	std::lock_guard lock(m_mutex);
+	for (auto& s : m_sinks) {
+		s->flush();
 	}
 }
 
 auto gse::log::instance() -> logger& {
 	static logger s_logger;
 	return s_logger;
+}
+
+auto gse::log::add_sink(std::unique_ptr<sink> s) -> sink* {
+	return instance().add_sink(std::move(s));
 }
 
 auto gse::log::flush() -> void {

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -19,13 +19,28 @@ namespace gse::log {
 		level lvl
 	) -> bool;
 
+	auto rotate_logs(
+		const std::filesystem::path& path,
+		std::size_t max_files
+	) -> void;
+
+	auto level_sgr(
+		level lvl
+	) -> int;
+
 	constexpr auto category_count = std::define_static_array(std::meta::enumerators_of(^^category)).size();
 
 	constexpr std::size_t no_thread_index = std::numeric_limits<std::size_t>::max();
 
+	constexpr std::size_t log_files_kept = 5;
+
 	std::array<std::atomic<level>, category_count> category_levels;
 
 	std::atomic<std::size_t> backtrace_size = 0;
+
+	std::atomic<bool> color_enabled = true;
+
+	std::atomic<bool> logger_alive = false;
 
 	thread_local thread_role t_thread_role = thread_role::unknown;
 
@@ -46,8 +61,9 @@ namespace gse::log {
 
 	class file_sink : public sink {
 	public:
-		explicit file_sink(
-			std::filesystem::path path
+		file_sink(
+			std::filesystem::path path,
+			std::size_t max_files
 		);
 
 		auto write(
@@ -121,9 +137,17 @@ namespace gse::log {
 
 		auto dump_backtrace_locked() -> void;
 
+		auto emit_repeat_summary() -> void;
+
 		std::vector<std::unique_ptr<sink>> m_sinks;
 		std::mutex m_sink_mutex;
 		std::deque<queued_record> m_backtrace;
+
+		level m_last_level = level::info;
+		category m_last_cat = category::general;
+		std::string m_last_message;
+		std::uint64_t m_repeat_count = 0;
+		bool m_has_last = false;
 
 		moodycamel::ConcurrentQueue<queued_record> m_queue;
 		std::counting_semaphore<> m_items{ 0 };
@@ -226,11 +250,28 @@ auto gse::log::format_line(const record& rec) -> std::string {
 	return std::format("[{}][{}][{}][{}] {}{}", rec.timestamp, rec.lvl, rec.cat, rec.thread, rec.prefix, rec.message);
 }
 
+auto gse::log::level_sgr(const level lvl) -> int {
+	template for (constexpr auto e : std::define_static_array(std::meta::enumerators_of(^^level))) {
+		constexpr auto ann = first_annotation_of_type(e, ^^ansi_sgr);
+		if constexpr (ann != std::meta::info{}) {
+			if ([:e:] == lvl) {
+				return [:std::meta::constant_of(ann):].code;
+			}
+		}
+	}
+	return 0;
+}
+
 gse::log::sink::~sink() = default;
 
 auto gse::log::console_sink::write(const record& rec) -> void {
 	auto& os = should_flush(rec.lvl) ? static_cast<std::ostream&>(std::cerr) : static_cast<std::ostream&>(std::cout);
-	std::print(os, "{}\n", format_line(rec));
+	const auto line = format_line(rec);
+	if (color_enabled.load(std::memory_order_relaxed)) {
+		std::print(os, "\033[{}m{}\033[0m\n", level_sgr(rec.lvl), line);
+		return;
+	}
+	std::print(os, "{}\n", line);
 }
 
 auto gse::log::console_sink::write_raw(const std::string_view text) -> void {
@@ -242,9 +283,33 @@ auto gse::log::console_sink::flush() -> void {
 	std::cerr.flush();
 }
 
-gse::log::file_sink::file_sink(const std::filesystem::path path) {
+auto gse::log::rotate_logs(const std::filesystem::path& path, const std::size_t max_files) -> void {
+	if (max_files <= 1) {
+		return;
+	}
+
+	const auto dir = path.parent_path();
+	const auto stem = path.stem().string();
+	const auto ext = path.extension().string();
+
+	auto nth = [&](const std::size_t i) -> std::filesystem::path {
+		if (i == 0) {
+			return path;
+		}
+		return dir / std::format("{}.{}{}", stem, i, ext);
+	};
+
+	std::error_code ec;
+	std::filesystem::remove(nth(max_files - 1), ec);
+	for (std::size_t i = max_files - 1; i > 0; --i) {
+		std::filesystem::rename(nth(i - 1), nth(i), ec);
+	}
+}
+
+gse::log::file_sink::file_sink(const std::filesystem::path path, const std::size_t max_files) {
 	std::error_code ec;
 	std::filesystem::create_directories(path.parent_path(), ec);
+	rotate_logs(path, max_files);
 	m_file.open(path, std::ios::out | std::ios::trunc);
 }
 
@@ -268,16 +333,19 @@ auto gse::log::file_sink::flush() -> void {
 
 gse::log::logger::logger() {
 	m_sinks.push_back(std::make_unique<console_sink>());
-	m_sinks.push_back(std::make_unique<file_sink>(log_file_path()));
+	m_sinks.push_back(std::make_unique<file_sink>(log_file_path(), log_files_kept));
 
 	const auto marker = std::format("=== Log started at {} ===", timestamp_string());
 	for (auto& s : m_sinks) {
 		s->write_raw(marker);
 		s->flush();
 	}
+
+	logger_alive.store(true, std::memory_order_relaxed);
 }
 
 gse::log::logger::~logger() {
+	logger_alive.store(false, std::memory_order_relaxed);
 	set_async(false);
 
 	std::lock_guard lock(m_sink_mutex);
@@ -296,6 +364,10 @@ gse::log::logger::~logger() {
 		}
 	}
 
+	if (m_repeat_count > 0) {
+		emit_repeat_summary();
+	}
+
 	const auto marker = std::format("=== Log ended at {} ===", timestamp_string());
 	for (auto& s : m_sinks) {
 		s->write_raw(marker);
@@ -304,11 +376,42 @@ gse::log::logger::~logger() {
 }
 
 auto gse::log::logger::dispatch(const record& rec) -> void {
+	if (m_has_last && rec.lvl == m_last_level && rec.cat == m_last_cat && rec.message == m_last_message) {
+		++m_repeat_count;
+		return;
+	}
+	if (m_repeat_count > 0) {
+		emit_repeat_summary();
+	}
 	for (auto& s : m_sinks) {
 		if (rec.lvl >= s->min_level.load(std::memory_order_relaxed)) {
 			s->write(rec);
 		}
 	}
+	m_last_level = rec.lvl;
+	m_last_cat = rec.cat;
+	m_last_message = rec.message;
+	m_has_last = true;
+}
+
+auto gse::log::logger::emit_repeat_summary() -> void {
+	const auto ts = timestamp_string();
+	const auto thread = thread_display();
+	const auto message = std::format("(previous message repeated {} times)", m_repeat_count);
+	const record rec{
+		.lvl = m_last_level,
+		.cat = m_last_cat,
+		.timestamp = ts,
+		.thread = thread,
+		.prefix = {},
+		.message = message,
+	};
+	for (auto& s : m_sinks) {
+		if (rec.lvl >= s->min_level.load(std::memory_order_relaxed)) {
+			s->write(rec);
+		}
+	}
+	m_repeat_count = 0;
 }
 
 auto gse::log::logger::process(const queued_record& qr) -> bool {
@@ -578,6 +681,12 @@ auto gse::log::logger::flush() -> void {
 }
 
 auto gse::log::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
+	if (!logger_alive.load(std::memory_order_relaxed)) {
+		const auto message = std::vformat(fmt, args);
+		std::fputs(message.c_str(), stderr);
+		std::fputc('\n', stderr);
+		return;
+	}
 	instance.write_line(lvl, cat, extra_prefix, fmt, args);
 }
 
@@ -590,6 +699,9 @@ auto gse::log::set_async(const bool enabled) -> void {
 }
 
 auto gse::log::flush() -> void {
+	if (!logger_alive.load(std::memory_order_relaxed)) {
+		return;
+	}
 	instance.flush();
 }
 
@@ -608,4 +720,8 @@ auto gse::log::dump_backtrace() -> void {
 
 auto gse::log::backtrace_active() -> bool {
 	return backtrace_size.load(std::memory_order_relaxed) > 0;
+}
+
+auto gse::log::set_color(const bool enabled) -> void {
+	color_enabled.store(enabled, std::memory_order_relaxed);
 }

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -4,6 +4,7 @@ import std;
 
 import gse.config;
 import gse.meta;
+import gse.moodycamel;
 
 namespace gse::log {
 	auto log_file_path() -> std::filesystem::path;
@@ -60,6 +61,70 @@ namespace gse::log {
 	private:
 		std::ofstream m_file;
 	};
+
+	struct queued_record {
+		enum class kind : std::uint8_t {
+			log,
+			flush,
+			terminate
+		};
+
+		kind type = kind::log;
+		level lvl = level::info;
+		category cat = category::general;
+		std::uint64_t token = 0;
+		std::string timestamp;
+		std::string thread;
+		std::string prefix;
+		std::string message;
+	};
+
+	class logger {
+	public:
+		logger();
+		~logger();
+
+		auto write_line(
+			level lvl,
+			category cat,
+			std::string_view extra_prefix,
+			std::string_view fmt,
+			std::format_args args
+		) -> void;
+
+		auto add_sink(
+			std::unique_ptr<sink> s
+		) -> sink*;
+
+		auto set_async(
+			bool enabled
+		) -> void;
+
+		auto flush() -> void;
+
+	private:
+		auto dispatch(
+			const record& rec
+		) -> void;
+
+		auto run() -> void;
+
+		std::vector<std::unique_ptr<sink>> m_sinks;
+		std::mutex m_sink_mutex;
+
+		moodycamel::ConcurrentQueue<queued_record> m_queue;
+		std::counting_semaphore<> m_items{ 0 };
+
+		std::mutex m_flush_mutex;
+		std::condition_variable m_flushed;
+		std::atomic<std::uint64_t> m_flush_seq = 0;
+		std::atomic<std::uint64_t> m_flush_done = 0;
+
+		std::atomic<bool> m_async = false;
+		std::thread m_worker;
+	};
+
+	auto instance() -> logger&;
 }
 
 auto gse::log::log_file_path() -> std::filesystem::path {
@@ -200,6 +265,24 @@ gse::log::logger::logger() {
 }
 
 gse::log::logger::~logger() {
+	set_async(false);
+
+	std::lock_guard lock(m_sink_mutex);
+	queued_record qr;
+	while (m_queue.try_dequeue(qr)) {
+		if (qr.type == queued_record::kind::log) {
+			const record rec{
+				.lvl = qr.lvl,
+				.cat = qr.cat,
+				.timestamp = qr.timestamp,
+				.thread = qr.thread,
+				.prefix = qr.prefix,
+				.message = qr.message,
+			};
+			dispatch(rec);
+		}
+	}
+
 	const auto marker = std::format("=== Log ended at {} ===", timestamp_string());
 	for (auto& s : m_sinks) {
 		s->write_raw(marker);
@@ -207,13 +290,100 @@ gse::log::logger::~logger() {
 	}
 }
 
+auto gse::log::logger::dispatch(const record& rec) -> void {
+	for (auto& s : m_sinks) {
+		if (rec.lvl >= s->min_level.load(std::memory_order_relaxed)) {
+			s->write(rec);
+		}
+	}
+}
+
+auto gse::log::logger::run() -> void {
+	std::vector<queued_record> batch;
+	for (;;) {
+		m_items.acquire();
+		std::size_t pending = 1;
+		while (m_items.try_acquire()) {
+			++pending;
+		}
+
+		batch.clear();
+		for (std::size_t i = 0; i < pending; ++i) {
+			queued_record qr;
+			while (!m_queue.try_dequeue(qr)) {
+			}
+			batch.push_back(std::move(qr));
+		}
+
+		bool needs_flush = false;
+		std::uint64_t flush_token = 0;
+		bool terminate = false;
+		{
+			std::lock_guard sink_lock(m_sink_mutex);
+			for (const auto& qr : batch) {
+				if (qr.type == queued_record::kind::terminate) {
+					terminate = true;
+					continue;
+				}
+				if (qr.type == queued_record::kind::flush) {
+					needs_flush = true;
+					flush_token = std::max(flush_token, qr.token);
+					continue;
+				}
+				const record rec{
+					.lvl = qr.lvl,
+					.cat = qr.cat,
+					.timestamp = qr.timestamp,
+					.thread = qr.thread,
+					.prefix = qr.prefix,
+					.message = qr.message,
+				};
+				dispatch(rec);
+				if (should_flush(qr.lvl)) {
+					needs_flush = true;
+				}
+			}
+			if (needs_flush) {
+				for (auto& s : m_sinks) {
+					s->flush();
+				}
+			}
+		}
+
+		if (flush_token != 0) {
+			{
+				std::lock_guard fl(m_flush_mutex);
+				m_flush_done.store(flush_token, std::memory_order_relaxed);
+			}
+			m_flushed.notify_all();
+		}
+
+		if (terminate) {
+			break;
+		}
+	}
+}
+
 auto gse::log::logger::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
-	std::lock_guard lock(m_mutex);
+	auto ts = timestamp_string();
+	auto thread = thread_display();
+	auto message = std::vformat(fmt, args);
 
-	const auto ts = timestamp_string();
-	const auto thread = thread_display();
-	const auto message = std::vformat(fmt, args);
+	if (m_async.load(std::memory_order_acquire)) {
+		m_queue.enqueue(queued_record{
+			.type = queued_record::kind::log,
+			.lvl = lvl,
+			.cat = cat,
+			.timestamp = std::move(ts),
+			.thread = std::move(thread),
+			.prefix = std::string(extra_prefix),
+			.message = std::move(message),
+		});
+		m_items.release();
+		return;
+	}
 
+	std::lock_guard sink_lock(m_sink_mutex);
 	const record rec{
 		.lvl = lvl,
 		.cat = cat,
@@ -222,13 +392,7 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 		.prefix = extra_prefix,
 		.message = message,
 	};
-
-	for (auto& s : m_sinks) {
-		if (lvl >= s->min_level.load(std::memory_order_relaxed)) {
-			s->write(rec);
-		}
-	}
-
+	dispatch(rec);
 	if (should_flush(lvl)) {
 		for (auto& s : m_sinks) {
 			s->flush();
@@ -237,15 +401,72 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 }
 
 auto gse::log::logger::add_sink(std::unique_ptr<sink> s) -> sink* {
-	std::lock_guard lock(m_mutex);
+	std::lock_guard lock(m_sink_mutex);
 	return m_sinks.emplace_back(std::move(s)).get();
 }
 
-auto gse::log::logger::flush() -> void {
-	std::lock_guard lock(m_mutex);
-	for (auto& s : m_sinks) {
-		s->flush();
+auto gse::log::logger::set_async(const bool enabled) -> void {
+	if (enabled) {
+		if (m_async.exchange(true)) {
+			return;
+		}
+		m_flush_seq.store(0, std::memory_order_relaxed);
+		m_flush_done.store(0, std::memory_order_relaxed);
+		m_worker = std::thread([this] {
+			run();
+		});
+		return;
 	}
+
+	if (!m_async.exchange(false)) {
+		return;
+	}
+
+	m_queue.enqueue(queued_record{ .type = queued_record::kind::terminate });
+	m_items.release();
+	if (m_worker.joinable()) {
+		m_worker.join();
+	}
+
+	std::lock_guard sink_lock(m_sink_mutex);
+	queued_record qr;
+	while (m_queue.try_dequeue(qr)) {
+		if (qr.type == queued_record::kind::log) {
+			const record rec{
+				.lvl = qr.lvl,
+				.cat = qr.cat,
+				.timestamp = qr.timestamp,
+				.thread = qr.thread,
+				.prefix = qr.prefix,
+				.message = qr.message,
+			};
+			dispatch(rec);
+		}
+	}
+	while (m_items.try_acquire()) {
+	}
+}
+
+auto gse::log::logger::flush() -> void {
+	if (!m_async.load(std::memory_order_acquire)) {
+		std::lock_guard sink_lock(m_sink_mutex);
+		for (auto& s : m_sinks) {
+			s->flush();
+		}
+		return;
+	}
+
+	const auto token = m_flush_seq.fetch_add(1, std::memory_order_relaxed) + 1;
+	m_queue.enqueue(queued_record{
+		.type = queued_record::kind::flush,
+		.token = token,
+	});
+	m_items.release();
+
+	std::unique_lock lk(m_flush_mutex);
+	m_flushed.wait(lk, [this, token] {
+		return m_flush_done.load(std::memory_order_relaxed) >= token || !m_async.load(std::memory_order_relaxed);
+	});
 }
 
 auto gse::log::instance() -> logger& {
@@ -253,8 +474,16 @@ auto gse::log::instance() -> logger& {
 	return s_logger;
 }
 
+auto gse::log::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
+	instance().write_line(lvl, cat, extra_prefix, fmt, args);
+}
+
 auto gse::log::add_sink(std::unique_ptr<sink> s) -> sink* {
 	return instance().add_sink(std::move(s));
+}
+
+auto gse::log::set_async(const bool enabled) -> void {
+	instance().set_async(enabled);
 }
 
 auto gse::log::flush() -> void {

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -23,7 +23,9 @@ namespace gse::log {
 
 	constexpr std::size_t no_thread_index = std::numeric_limits<std::size_t>::max();
 
-	std::array<std::atomic<level>, category_count> g_category_levels;
+	std::array<std::atomic<level>, category_count> category_levels;
+
+	std::atomic<std::size_t> backtrace_size = 0;
 
 	thread_local thread_role t_thread_role = thread_role::unknown;
 
@@ -102,6 +104,10 @@ namespace gse::log {
 
 		auto flush() -> void;
 
+		auto dump_backtrace() -> void;
+
+		auto clear_backtrace() -> void;
+
 	private:
 		auto dispatch(
 			const record& rec
@@ -109,8 +115,15 @@ namespace gse::log {
 
 		auto run() -> void;
 
+		auto process(
+			const queued_record& qr
+		) -> bool;
+
+		auto dump_backtrace_locked() -> void;
+
 		std::vector<std::unique_ptr<sink>> m_sinks;
 		std::mutex m_sink_mutex;
+		std::deque<queued_record> m_backtrace;
 
 		moodycamel::ConcurrentQueue<queued_record> m_queue;
 		std::counting_semaphore<> m_items{ 0 };
@@ -124,7 +137,7 @@ namespace gse::log {
 		std::thread m_worker;
 	};
 
-	auto instance() -> logger&;
+	logger instance;
 }
 
 auto gse::log::log_file_path() -> std::filesystem::path {
@@ -160,21 +173,21 @@ auto gse::log::thread_display() -> std::string {
 }
 
 auto gse::log::set_level(const level min) -> void {
-	for (auto& slot : g_category_levels) {
+	for (auto& slot : category_levels) {
 		slot.store(min, std::memory_order_relaxed);
 	}
 }
 
 auto gse::log::set_level(const category cat, const level min) -> void {
-	g_category_levels[static_cast<std::size_t>(cat)].store(min, std::memory_order_relaxed);
+	category_levels[static_cast<std::size_t>(cat)].store(min, std::memory_order_relaxed);
 }
 
 auto gse::log::level_of(const category cat) -> level {
-	return g_category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
+	return category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
 }
 
 auto gse::log::enabled(const level lvl, const category cat) -> bool {
-	return lvl >= g_category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
+	return lvl >= category_levels[static_cast<std::size_t>(cat)].load(std::memory_order_relaxed);
 }
 
 auto gse::log::name_thread(const thread_role role) -> void {
@@ -298,6 +311,70 @@ auto gse::log::logger::dispatch(const record& rec) -> void {
 	}
 }
 
+auto gse::log::logger::process(const queued_record& qr) -> bool {
+	const bool pass = enabled(qr.lvl, qr.cat);
+	if (backtrace_size.load(std::memory_order_relaxed) > 0) {
+		if (pass && should_flush(qr.lvl)) {
+			dump_backtrace_locked();
+		}
+		if (!pass) {
+			m_backtrace.push_back(qr);
+			while (m_backtrace.size() > backtrace_size.load(std::memory_order_relaxed)) {
+				m_backtrace.pop_front();
+			}
+		}
+	}
+	if (!pass) {
+		return false;
+	}
+	const record rec{
+		.lvl = qr.lvl,
+		.cat = qr.cat,
+		.timestamp = qr.timestamp,
+		.thread = qr.thread,
+		.prefix = qr.prefix,
+		.message = qr.message,
+	};
+	dispatch(rec);
+	return should_flush(qr.lvl);
+}
+
+auto gse::log::logger::dump_backtrace_locked() -> void {
+	if (m_backtrace.empty()) {
+		return;
+	}
+	for (auto& s : m_sinks) {
+		s->write_raw(std::format("====== backtrace: {} held record(s) ======", m_backtrace.size()));
+	}
+	for (const auto& qr : m_backtrace) {
+		const record rec{
+			.lvl = qr.lvl,
+			.cat = qr.cat,
+			.timestamp = qr.timestamp,
+			.thread = qr.thread,
+			.prefix = qr.prefix,
+			.message = qr.message,
+		};
+		for (auto& s : m_sinks) {
+			s->write(rec);
+		}
+	}
+	for (auto& s : m_sinks) {
+		s->write_raw("====== end backtrace ======");
+	}
+	m_backtrace.clear();
+}
+
+auto gse::log::logger::dump_backtrace() -> void {
+	std::lock_guard sink_lock(m_sink_mutex);
+	dump_backtrace_locked();
+}
+
+auto gse::log::logger::clear_backtrace() -> void {
+	std::lock_guard sink_lock(m_sink_mutex);
+	m_backtrace.clear();
+}
+
 auto gse::log::logger::run() -> void {
 	std::vector<queued_record> batch;
 	for (;;) {
@@ -330,16 +407,7 @@ auto gse::log::logger::run() -> void {
 					flush_token = std::max(flush_token, qr.token);
 					continue;
 				}
-				const record rec{
-					.lvl = qr.lvl,
-					.cat = qr.cat,
-					.timestamp = qr.timestamp,
-					.thread = qr.thread,
-					.prefix = qr.prefix,
-					.message = qr.message,
-				};
-				dispatch(rec);
-				if (should_flush(qr.lvl)) {
+				if (process(qr)) {
 					needs_flush = true;
 				}
 			}
@@ -380,6 +448,25 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 			.message = std::move(message),
 		});
 		m_items.release();
+		return;
+	}
+
+	if (backtrace_size.load(std::memory_order_relaxed) > 0) {
+		queued_record qr{
+			.type = queued_record::kind::log,
+			.lvl = lvl,
+			.cat = cat,
+			.timestamp = std::move(ts),
+			.thread = std::move(thread),
+			.prefix = std::string(extra_prefix),
+			.message = std::move(message),
+		};
+		std::lock_guard sink_lock(m_sink_mutex);
+		if (process(qr)) {
+			for (auto& s : m_sinks) {
+				s->flush();
+			}
+		}
 		return;
 	}
 
@@ -469,23 +556,35 @@ auto gse::log::logger::flush() -> void {
 	});
 }
 
-auto gse::log::instance() -> logger& {
-	static logger s_logger;
-	return s_logger;
-}
-
 auto gse::log::write_line(const level lvl, const category cat, const std::string_view extra_prefix, const std::string_view fmt, std::format_args args) -> void {
-	instance().write_line(lvl, cat, extra_prefix, fmt, args);
+	instance.write_line(lvl, cat, extra_prefix, fmt, args);
 }
 
 auto gse::log::add_sink(std::unique_ptr<sink> s) -> sink* {
-	return instance().add_sink(std::move(s));
+	return instance.add_sink(std::move(s));
 }
 
 auto gse::log::set_async(const bool enabled) -> void {
-	instance().set_async(enabled);
+	instance.set_async(enabled);
 }
 
 auto gse::log::flush() -> void {
-	instance().flush();
+	instance.flush();
+}
+
+auto gse::log::enable_backtrace(const std::size_t size) -> void {
+	backtrace_size.store(size, std::memory_order_relaxed);
+}
+
+auto gse::log::disable_backtrace() -> void {
+	backtrace_size.store(0, std::memory_order_relaxed);
+	instance.clear_backtrace();
+}
+
+auto gse::log::dump_backtrace() -> void {
+	instance.dump_backtrace();
+}
+
+auto gse::log::backtrace_active() -> bool {
+	return backtrace_size.load(std::memory_order_relaxed) > 0;
 }

--- a/Engine/Engine/Import/Log.cpp
+++ b/Engine/Engine/Import/Log.cpp
@@ -28,6 +28,10 @@ namespace gse::log {
 		level lvl
 	) -> int;
 
+	auto json_escape(
+		std::string_view text
+	) -> std::string;
+
 	constexpr auto category_count = std::define_static_array(std::meta::enumerators_of(^^category)).size();
 
 	constexpr std::size_t no_thread_index = std::numeric_limits<std::size_t>::max();
@@ -45,6 +49,8 @@ namespace gse::log {
 	thread_local thread_role t_thread_role = thread_role::unknown;
 
 	thread_local std::size_t t_thread_index = no_thread_index;
+
+	thread_local std::string t_context;
 
 	class console_sink : public sink {
 	public:
@@ -248,6 +254,83 @@ auto gse::log::sampler::tick() -> bool {
 
 auto gse::log::format_line(const record& rec) -> std::string {
 	return std::format("[{}][{}][{}][{}] {}{}", rec.timestamp, rec.lvl, rec.cat, rec.thread, rec.prefix, rec.message);
+}
+
+auto gse::log::json_escape(const std::string_view text) -> std::string {
+	std::string out;
+	out.reserve(text.size() + 8);
+	for (const char c : text) {
+		switch (c) {
+			case '"':
+				out += "\\\"";
+				break;
+			case '\\':
+				out += "\\\\";
+				break;
+			case '\n':
+				out += "\\n";
+				break;
+			case '\r':
+				out += "\\r";
+				break;
+			case '\t':
+				out += "\\t";
+				break;
+			default:
+				if (static_cast<unsigned char>(c) < 0x20) {
+					out += std::format("\\u{:04x}", static_cast<unsigned>(static_cast<unsigned char>(c)));
+					break;
+				}
+				out += c;
+				break;
+		}
+	}
+	return out;
+}
+
+gse::log::json_sink::json_sink(const std::filesystem::path path) {
+	std::error_code ec;
+	std::filesystem::create_directories(path.parent_path(), ec);
+	m_file.open(path, std::ios::out | std::ios::trunc);
+}
+
+auto gse::log::json_sink::write(const record& rec) -> void {
+	if (!m_file.is_open()) {
+		return;
+	}
+	std::print(
+		m_file,
+		R"({{"time":"{}","level":"{}","category":"{}","thread":"{}","message":"{}"}})"
+		"\n",
+		rec.timestamp,
+		rec.lvl,
+		rec.cat,
+		rec.thread,
+		json_escape(std::format("{}{}", rec.prefix, rec.message))
+	);
+}
+
+auto gse::log::json_sink::write_raw(const std::string_view text) -> void {
+	if (!m_file.is_open()) {
+		return;
+	}
+	std::print(m_file, R"({{"raw":"{}"}})" "\n", json_escape(text));
+}
+
+auto gse::log::json_sink::flush() -> void {
+	if (m_file.is_open()) {
+		m_file.flush();
+	}
+}
+
+gse::log::scope::scope(const std::string_view label) {
+	m_restore = t_context.size();
+	t_context += label;
+	t_context += ' ';
+}
+
+gse::log::scope::~scope() {
+	t_context.resize(m_restore);
 }
 
 auto gse::log::level_sgr(const level lvl) -> int {
@@ -540,6 +623,15 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 	auto thread = thread_display();
 	auto message = std::vformat(fmt, args);
 
+	std::string context_buf;
+	std::string_view prefix = extra_prefix;
+	if (!t_context.empty()) {
+		context_buf.reserve(t_context.size() + extra_prefix.size());
+		context_buf += t_context;
+		context_buf += extra_prefix;
+		prefix = context_buf;
+	}
+
 	if (lvl == level::fatal) {
 		flush();
 		std::lock_guard sink_lock(m_sink_mutex);
@@ -549,7 +641,7 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 			.cat = cat,
 			.timestamp = ts,
 			.thread = thread,
-			.prefix = extra_prefix,
+			.prefix = prefix,
 			.message = message,
 		};
 		for (auto& s : m_sinks) {
@@ -568,7 +660,7 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 			.cat = cat,
 			.timestamp = std::move(ts),
 			.thread = std::move(thread),
-			.prefix = std::string(extra_prefix),
+			.prefix = std::string(prefix),
 			.message = std::move(message),
 		});
 		m_items.release();
@@ -582,7 +674,7 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 			.cat = cat,
 			.timestamp = std::move(ts),
 			.thread = std::move(thread),
-			.prefix = std::string(extra_prefix),
+			.prefix = std::string(prefix),
 			.message = std::move(message),
 		};
 		std::lock_guard sink_lock(m_sink_mutex);
@@ -600,7 +692,7 @@ auto gse::log::logger::write_line(const level lvl, const category cat, const std
 		.cat = cat,
 		.timestamp = ts,
 		.thread = thread,
-		.prefix = extra_prefix,
+		.prefix = prefix,
 		.message = message,
 	};
 	dispatch(rec);

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -7,7 +7,8 @@ export namespace gse::log {
 		debug,
 		info,
 		warning,
-		error
+		error,
+		fatal
 	};
 
 	enum class category : std::uint8_t {

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -32,7 +32,10 @@ export namespace gse::log {
 	enum class thread_role : std::uint8_t {
 		unknown,
 		main,
-		worker
+		worker,
+		watchdog,
+		capture,
+		network
 	};
 
 	auto set_level(

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -24,6 +24,98 @@ export namespace gse::log {
 		physics
 	};
 
+	enum class thread_role : std::uint8_t {
+		unknown,
+		main,
+		worker
+	};
+
+	auto set_level(
+		level min
+	) -> void;
+
+	auto set_level(
+		category cat,
+		level min
+	) -> void;
+
+	auto level_of(
+		category cat
+	) -> level;
+
+	auto enabled(
+		level lvl,
+		category cat
+	) -> bool;
+
+	class sampler {
+	public:
+		explicit sampler(
+			std::uint64_t every
+		);
+
+		explicit sampler(
+			std::chrono::steady_clock::duration min_interval
+		);
+
+		auto tick() -> bool;
+
+	private:
+		enum class mode : std::uint8_t {
+			count,
+			interval
+		};
+
+		mode m_mode;
+		std::uint64_t m_every = 1;
+		std::chrono::steady_clock::duration m_interval = {};
+		std::atomic<std::uint64_t> m_count = 0;
+		std::atomic<std::chrono::steady_clock::rep> m_last = 0;
+	};
+
+	auto name_thread(
+		thread_role role
+	) -> void;
+
+	auto name_thread(
+		thread_role role,
+		std::size_t index
+	) -> void;
+
+	struct record {
+		level lvl;
+		category cat;
+		std::string_view timestamp;
+		std::string_view thread;
+		std::string_view prefix;
+		std::string_view message;
+	};
+
+	auto format_line(
+		const record& rec
+	) -> std::string;
+
+	class sink {
+	public:
+		virtual ~sink();
+
+		virtual auto write(
+			const record& rec
+		) -> void = 0;
+
+		virtual auto write_raw(
+			std::string_view text
+		) -> void = 0;
+
+		virtual auto flush() -> void = 0;
+
+		std::atomic<level> min_level = level::debug;
+	};
+
+	auto add_sink(
+		std::unique_ptr<sink> s
+	) -> sink*;
+
 	template <typename... Args>
 	auto println(
 		std::format_string<Args...> fmt,
@@ -86,10 +178,14 @@ namespace gse::log {
 			std::format_args args
 		) -> void;
 
+		auto add_sink(
+			std::unique_ptr<sink> s
+		) -> sink*;
+
 		auto flush() -> void;
 
 	private:
-		std::ofstream m_file;
+		std::vector<std::unique_ptr<sink>> m_sinks;
 		std::mutex m_mutex;
 	};
 
@@ -118,6 +214,10 @@ auto gse::log::println(const category cat, std::format_string<Args...> fmt, cons
 
 template <typename... Args>
 auto gse::log::println(const level lvl, const category cat, std::format_string<Args...> fmt, const Args&... args) -> void {
+	if (!enabled(lvl, cat)) {
+		return;
+	}
+
 	instance().write_line(
 		lvl,
 		cat,
@@ -129,6 +229,10 @@ auto gse::log::println(const level lvl, const category cat, std::format_string<A
 
 template <typename... Args>
 auto gse::log::println(const level lvl, const category cat, const std::source_location loc, std::format_string<Args...> fmt, const Args&... args) -> void {
+	if (!enabled(lvl, cat)) {
+		return;
+	}
+
 	const auto loc_prefix = std::format("{}:{} - ", loc.file_name(), loc.line());
 	instance().write_line(lvl, cat, loc_prefix, fmt.get(), std::make_format_args(args...));
 }

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -3,12 +3,16 @@ export module gse.log;
 import std;
 
 export namespace gse::log {
+	struct ansi_sgr {
+		int code;
+	};
+
 	enum class level : std::uint8_t {
-		debug,
-		info,
-		warning,
-		error,
-		fatal
+		debug [[= ansi_sgr{ 90 }]],
+		info [[= ansi_sgr{ 0 }]],
+		warning [[= ansi_sgr{ 33 }]],
+		error [[= ansi_sgr{ 31 }]],
+		fatal [[= ansi_sgr{ 91 }]]
 	};
 
 	enum class category : std::uint8_t {
@@ -130,6 +134,10 @@ export namespace gse::log {
 	auto dump_backtrace() -> void;
 
 	auto backtrace_active() -> bool;
+
+	auto set_color(
+		bool enabled
+	) -> void;
 
 	template <typename... Args>
 	auto println(

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -116,6 +116,10 @@ export namespace gse::log {
 		std::unique_ptr<sink> s
 	) -> sink*;
 
+	auto set_async(
+		bool enabled
+	) -> void;
+
 	template <typename... Args>
 	auto println(
 		std::format_string<Args...> fmt,
@@ -165,31 +169,13 @@ export namespace gse::log {
 }
 
 namespace gse::log {
-	class logger {
-	public:
-		logger();
-		~logger();
-
-		auto write_line(
-			level lvl,
-			category cat,
-			std::string_view extra_prefix,
-			std::string_view fmt,
-			std::format_args args
-		) -> void;
-
-		auto add_sink(
-			std::unique_ptr<sink> s
-		) -> sink*;
-
-		auto flush() -> void;
-
-	private:
-		std::vector<std::unique_ptr<sink>> m_sinks;
-		std::mutex m_mutex;
-	};
-
-	auto instance() -> logger&;
+	auto write_line(
+		level lvl,
+		category cat,
+		std::string_view extra_prefix,
+		std::string_view fmt,
+		std::format_args args
+	) -> void;
 }
 
 template <typename... Args>
@@ -218,7 +204,7 @@ auto gse::log::println(const level lvl, const category cat, std::format_string<A
 		return;
 	}
 
-	instance().write_line(
+	write_line(
 		lvl,
 		cat,
 		{},
@@ -234,5 +220,5 @@ auto gse::log::println(const level lvl, const category cat, const std::source_lo
 	}
 
 	const auto loc_prefix = std::format("{}:{} - ", loc.file_name(), loc.line());
-	instance().write_line(lvl, cat, loc_prefix, fmt.get(), std::make_format_args(args...));
+	write_line(lvl, cat, loc_prefix, fmt.get(), std::make_format_args(args...));
 }

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -120,6 +120,41 @@ export namespace gse::log {
 		std::atomic<level> min_level = level::debug;
 	};
 
+	class json_sink : public sink {
+	public:
+		explicit json_sink(
+			std::filesystem::path path
+		);
+
+		auto write(
+			const record& rec
+		) -> void override;
+
+		auto write_raw(
+			std::string_view text
+		) -> void override;
+
+		auto flush() -> void override;
+
+	private:
+		std::ofstream m_file;
+	};
+
+	class scope {
+	public:
+		explicit scope(
+			std::string_view label
+		);
+
+		~scope();
+
+		scope(const scope&) = delete;
+		auto operator=(const scope&) -> scope& = delete;
+
+	private:
+		std::size_t m_restore;
+	};
+
 	auto add_sink(
 		std::unique_ptr<sink> s
 	) -> sink*;

--- a/Engine/Engine/Import/Log.cppm
+++ b/Engine/Engine/Import/Log.cppm
@@ -120,6 +120,16 @@ export namespace gse::log {
 		bool enabled
 	) -> void;
 
+	auto enable_backtrace(
+		std::size_t size
+	) -> void;
+
+	auto disable_backtrace() -> void;
+
+	auto dump_backtrace() -> void;
+
+	auto backtrace_active() -> bool;
+
 	template <typename... Args>
 	auto println(
 		std::format_string<Args...> fmt,
@@ -200,7 +210,7 @@ auto gse::log::println(const category cat, std::format_string<Args...> fmt, cons
 
 template <typename... Args>
 auto gse::log::println(const level lvl, const category cat, std::format_string<Args...> fmt, const Args&... args) -> void {
-	if (!enabled(lvl, cat)) {
+	if (!enabled(lvl, cat) && !backtrace_active()) {
 		return;
 	}
 
@@ -215,7 +225,7 @@ auto gse::log::println(const level lvl, const category cat, std::format_string<A
 
 template <typename... Args>
 auto gse::log::println(const level lvl, const category cat, const std::source_location loc, std::format_string<Args...> fmt, const Args&... args) -> void {
-	if (!enabled(lvl, cat)) {
+	if (!enabled(lvl, cat) && !backtrace_active()) {
 		return;
 	}
 

--- a/Engine/Engine/Source/Concurrency/Task.cppm
+++ b/Engine/Engine/Source/Concurrency/Task.cppm
@@ -825,6 +825,7 @@ auto gse::task::pool_start(const std::size_t worker_count) -> void {
 
 	for (std::size_t i = 0; i < background_workers; ++i) {
 		workers.emplace_back([i](std::stop_token st) {
+			log::name_thread(log::thread_role::worker, i);
 			worker_loop(st, i);
 		});
 	}
@@ -832,6 +833,7 @@ auto gse::task::pool_start(const std::size_t worker_count) -> void {
 	t_worker_index = worker_count - 1;
 	t_is_main_thread = true;
 	trace::register_main_thread();
+	log::name_thread(log::thread_role::main);
 }
 
 auto gse::task::pool_shutdown() -> void {

--- a/Engine/Engine/Source/Core/ID.cppm
+++ b/Engine/Engine/Source/Core/ID.cppm
@@ -437,10 +437,11 @@ namespace gse {
 		std::unordered_map<uuid, std::string> uuid_to_tag;
 	};
 
+	inline std::shared_mutex id_registry_mutex;
+	inline id_registry_data id_registry_state;
+
 	auto id_registry() -> std::pair<std::shared_mutex&, id_registry_data&> {
-		static std::shared_mutex m;
-		static id_registry_data instance;
-		return { m, instance };
+		return { id_registry_mutex, id_registry_state };
 	}
 }
 

--- a/Engine/Engine/Source/Diag/Watchdog.cpp
+++ b/Engine/Engine/Source/Diag/Watchdog.cpp
@@ -102,6 +102,7 @@ auto gse::watchdog::start() -> void {
 #endif
 
 	monitor = std::jthread([](std::stop_token st) {
+		log::name_thread(log::thread_role::watchdog);
 		monitor_loop(st);
 	});
 }

--- a/Engine/Engine/Source/Graphics/Renderers/CaptureRenderer.cpp
+++ b/Engine/Engine/Source/Graphics/Renderers/CaptureRenderer.cpp
@@ -297,6 +297,7 @@ auto gse::renderer::capture::frame(const context& ctx, shared_view<gpu::context:
 					d.recording->running = true;
 				}
 				d.recording->thread = std::thread([muxer = std::move(*live), state = d.recording.get()] mutable {
+					log::name_thread(log::thread_role::capture);
 					while (true) {
 						std::unique_lock lock(state->mutex);
 						state->cv.wait(

--- a/Engine/Engine/Source/Network/Client.cppm
+++ b/Engine/Engine/Source/Network/Client.cppm
@@ -125,6 +125,7 @@ gse::network::client::client(const address& listen, const address& server) : m_s
 	m_running.store(true, std::memory_order_release);
 
 	m_thread = std::jthread([this](const std::stop_token& st) {
+		log::name_thread(log::thread_role::network);
 		constexpr time_t<std::uint32_t> max_sleep = milliseconds(8);
 
 		while (m_running.load(std::memory_order_acquire) && !st.stop_requested()) {

--- a/Engine/Engine/Source/Runtime/Bootstrap.cppm
+++ b/Engine/Engine/Source/Runtime/Bootstrap.cppm
@@ -86,6 +86,8 @@ auto gse::start(app_setup_fn setup, const engine_config& config) -> void {
 
 		watchdog::start();
 
+		log::set_level(log::level::warning);
+		log::enable_backtrace(256);
 		log::set_async(true);
 
 		const auto loop_id = trace_id<"frame::loop">();

--- a/Engine/Engine/Source/Runtime/Bootstrap.cppm
+++ b/Engine/Engine/Source/Runtime/Bootstrap.cppm
@@ -86,6 +86,8 @@ auto gse::start(app_setup_fn setup, const engine_config& config) -> void {
 
 		watchdog::start();
 
+		log::set_async(true);
+
 		const auto loop_id = trace_id<"frame::loop">();
 		const auto poll_id = trace_id<"frame::poll_events">();
 		const auto sync_begin_id = trace_id<"frame::sync_begin">();
@@ -153,5 +155,6 @@ auto gse::start(app_setup_fn setup, const engine_config& config) -> void {
 		task::wait_idle();
 	});
 
+	log::set_async(false);
 	e.shutdown();
 }

--- a/Engine/Engine/Source/Runtime/Bootstrap.cppm
+++ b/Engine/Engine/Source/Runtime/Bootstrap.cppm
@@ -86,7 +86,7 @@ auto gse::start(app_setup_fn setup, const engine_config& config) -> void {
 
 		watchdog::start();
 
-		log::set_level(log::level::warning);
+		log::set_level(log::level::info);
 		log::enable_backtrace(256);
 		log::set_async(true);
 

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -1,0 +1,321 @@
+# Logger Improvement Backlog (ranked)
+
+Ranked list of features the current logger lacks relative to production loggers
+(spdlog, quill, glog, Boost.Log), tailored to this engine. Pick the top unstarted
+item, implement, check it off. Each entry is self-contained so a cold session can
+act on it without re-deriving context.
+
+Source: [Log.cppm](../Engine/Engine/Import/Log.cppm) (public API + templates),
+[Log.cpp](../Engine/Engine/Import/Log.cpp) (`logger` impl).
+Used at ~300 call sites across ~68 files, so **additive, backward-compatible
+changes are strongly preferred** over anything that touches the call API.
+
+Date drafted: 2026-06-19.
+
+## Status — branch `logger-improvements` (2026-06-20)
+
+- **#1 Runtime level filtering** — done. `set_level` (global + per-category),
+  `level_of`, `enabled` in `gse.log`. Default stays `debug` (nothing filtered)
+  until you raise it; setting the global threshold broadcasts to all categories.
+  Gate sits in the two leaf `println` templates, so `make_format_args` is skipped
+  when disabled.
+- **#2 Throttle / every-N** — partial. `log::sampler` (every-N + every-T,
+  lock-free, caller-owned `static`) done. Automatic "repeated N×" dedup still
+  deferred — it changes global logging semantics, so it wants its own opt-in.
+- **#4 Named threads** — done. Reflected `thread_role` enum (`unknown, main,
+  worker`) rendered via the same `std::formatter` / `enum_to_string` path as
+  `level` / `category`; `name_thread(role)` + `name_thread(role, index)`.
+  `write_line` shows `main` / `worker-3`, falls back to the hash when `unknown`.
+  Wired at `task::pool_start` (main) and the worker lambda. Kept independent of
+  the `trace` registry on purpose (no lock on the log hot path, no `gse.diag`
+  dependency in the universal logger). Dedicated watchdog / capture / network
+  threads exist too — one line each to name now that roles are cheap to add.
+  Task-origin labeling for the pool (the source_location idea) is the deliberate
+  follow-up — see #12.
+- **#5 Sink abstraction** — done. `write_line` fans each `record` out to a list
+  of `sink`s, each with its own `min_level` (a second filter under the global /
+  per-category one). Exports `sink` (write / write_raw / flush), `record`,
+  `format_line`, `add_sink(unique_ptr<sink>) -> sink*`; `console_sink` +
+  `file_sink` are the internal auto-registered defaults. `msvc_debug_sink`
+  deferred (Win32 `OutputDebugStringA` — keep the universal logger portable for
+  the gcc-trunk CI; trivial `#ifdef _WIN32` add later). Formatting centralized in
+  `format_line`; the message is now built once as a string — the hook #2-dedup
+  and #6 ring-buffer both need.
+- **#3 Async** — next, and now cleaner: the background thread just writes to the
+  sink list instead of cout/file directly.
+
+Everything below is the original plan, unchanged.
+
+## Current baseline (do not regress)
+
+- `std::format`-typed API with an overload ladder: `(fmt)`, `(level, fmt)`,
+  `(level, loc, fmt)`, `(category, fmt)`, `(level, category, fmt)`,
+  `(level, category, loc, fmt)`.
+- Levels: `debug, info, warning, error`. Categories: `general, runtime, render,
+  network, vulkan, vulkan_validation, vulkan_memory, assets, task, save_system,
+  physics`.
+- `level`/`category` stringify via the p2996 reflection formatters (Meta/Enum,
+  Meta/Format) — anything new added to those enums prints for free.
+- Thread-safe: single `std::mutex` in `logger`, held across formatting + I/O.
+- Fan-out to console (`cout`, or `cerr` when flushing) and a file.
+- UTC timestamps with ms precision; per-line thread tag; opt-in `source_location`.
+- Flush policy: flush on `error` only (`should_flush`, [Log.cpp:38](../Engine/Engine/Import/Log.cpp)).
+- File opened with `trunc` ([Log.cpp:45](../Engine/Engine/Import/Log.cpp)) — wipes prior run.
+- Singleton via function-local `static logger` (`instance()`, [Log.cpp:101](../Engine/Engine/Import/Log.cpp)).
+
+## Ranking at a glance
+
+| # | Feature | Impact | Effort | Back-compat | Depends on |
+|---|---------|--------|--------|-------------|------------|
+| 1 | Runtime level filtering (global + per-category) | High | Low | Yes | — |
+| 2 | Throttle / dedup / every-N | High | Low–Med | Yes | — |
+| 3 | Async / background-thread logging | High | Med–High | Yes (API unchanged) | benefits from #5 |
+| 4 | Named threads (vs hashed id) | Med–High | Low | Yes | thread registry |
+| 5 | Sink abstraction / multiple sinks | Med (High as enabler) | Med | Yes | — |
+| 6 | Ring-buffer backtrace (dump-on-error) | Med–High | Med | Yes | #5 (light) |
+| 7 | Log rotation / retention | Med | Med | Yes | #5 (light) |
+| 8 | Compile-time stripping in release | Med–High | Med + macro tension | New call form | — |
+| 9 | `fatal` level + Assert integration | Med | Low–Med | Yes (additive) | Assert.cppm |
+| 10 | Color console output by level | Low–Med | Low | Yes | #5 (light) |
+| 11 | Configurable pattern + structured/JSON sink | Low–Med | Med | Yes | #5 |
+| 12 | Scoped / thread-local context | Low–Med | Med | Yes (additive) | — |
+| 13 | Static-destruction safety | Low (correctness) | Low | Yes | — |
+
+## Sequencing notes
+
+- **#1 and #2 are the quick, high-value wins** — both drop into `write_line`,
+  both touch zero call sites. Do them first regardless of anything else.
+- **#5 (sink abstraction) is an enabler.** #6, #7, #10, #11 all layer on it
+  cleanly. If you intend to do two or more of those, pull #5 forward and build
+  them on top instead of retrofitting. If you only ever want one, skip #5.
+- **#4 (named threads) is an afternoon's work** and improves every single log
+  line's readability — pull it earlier than its rank if you want momentum, or
+  fold it into #3 since async output benefits most from readable thread labels.
+- **#3 (async) is the one with real design risk** (ordering, flush-on-crash,
+  shutdown drain). Don't start it on a tired evening.
+
+---
+
+## 1. Runtime level filtering (global + per-category)
+
+**What.** A minimum-level threshold, checked before any formatting work, plus a
+per-category override table.
+
+**Why.** Biggest functional gap. `debug` exists but is never filtered — every
+debug line formats and writes unconditionally. No way to say "vulkan at warning,
+physics at debug." Cuts noise and the bulk of logging cost in one change.
+
+**Effort.** Low. **Back-compat.** Full — purely additive.
+
+**Sketch.** In `gse::log`, add:
+
+```
+auto set_level(level min) -> void;
+auto set_level(category cat, level min) -> void;
+auto enabled(level lvl, category cat) -> bool;
+```
+
+Back them with a `std::atomic<level>` global and a
+`std::array<std::atomic<level>, category_count>` (default each to the global).
+First line of `write_line`: `if (!enabled(lvl, cat)) return;`. For the cheapest
+possible early-out, also gate inside the `println` templates so
+`std::make_format_args` is skipped when disabled.
+
+## 2. Throttle / dedup / every-N
+
+**What.** glog-style rate limiting: `every_n`, `first_n`, `every_t`, plus
+"last message repeated N×" collapsing for identical consecutive lines.
+
+**Why.** A per-frame loop spams identical errors every frame; this is the single
+biggest readability win for a real-time engine. Currently nothing prevents it.
+
+**Effort.** Low–Med. **Back-compat.** Additive (new overloads or a small policy
+arg/struct; leave existing calls untouched).
+
+**Sketch.** Keyed by `source_location` (file+line) so each call site has its own
+counter — store a `std::unordered_map<std::uintptr_t, count_state>` guarded by the
+existing mutex, or a small fixed cache. For consecutive-dedup, hash the formatted
+string and the (level, category); on match increment a counter and suppress, on
+change flush the "repeated N×" summary then print the new line.
+
+## 3. Async / background-thread logging
+
+**What.** Calling thread enqueues a log record; a dedicated thread formats and
+writes.
+
+**Why.** Today everything — timestamp, two `vprint` calls, file I/O — runs on the
+calling thread under one global mutex. Render and physics threads log per-frame
+and serialize on that mutex + block on disk. Async removes I/O from the hot path.
+
+**Effort.** Med–High (the risky one). **Back-compat.** Full — public API is
+unchanged; this is an internal swap of `write_line`'s tail.
+
+**Sketch.** [moodycamel concurrentqueue](../Engine/External/moodycamel/concurrentqueue.h)
+is already vendored. Enqueue a record `{ level, category, timestamp, thread tag,
+prefix, pre-formatted string }` — **format on the producer**, not the consumer, so
+captured arguments don't have to outlive the call (avoids lifetime hazards with
+`std::format_args`). Consumer thread drains and writes. Design carefully:
+- **Flush-on-error / crash:** synchronous path or block-until-drained for `error`/
+  `fatal`, so a crash doesn't lose the last lines.
+- **Shutdown:** drain the queue in the consumer-join before `~logger` closes the
+  file.
+- **Overflow policy:** bounded queue with either block or drop-oldest + a dropped
+  counter; decide explicitly.
+
+## 4. Named threads (vs hashed id)
+
+**What.** Replace `[T{:016x}]` (a `hash<thread::id>`, `current_thread_tag`,
+[Log.cpp:34](../Engine/Engine/Import/Log.cpp)) with human names: `render`,
+`physics`, `main`, `task-3`.
+
+**Why.** The hashed tag is unreadable. The engine already has a task/frame
+scheduler that owns its threads, so naming is natural and makes every line
+scannable.
+
+**Effort.** Low. **Back-compat.** Full.
+
+**Sketch.** `thread_local std::string t_name;` + `auto name_thread(std::string)`.
+Call it where worker threads start (FrameScheduler, task pool). Fall back to the
+short hash when unnamed. Pad/truncate to a fixed width for column alignment.
+
+## 5. Sink abstraction / multiple sinks
+
+**What.** A `sink` interface; the logger fans a record out to a list of sinks,
+each with its own level filter and (eventually) formatter.
+
+**Why.** Output is hardcoded to one `ofstream` + cout/cerr in `write_line`
+([Log.cpp:66](../Engine/Engine/Import/Log.cpp)). No way to add an in-game console
+overlay, a `OutputDebugStringA` sink (logs appear in the VS debugger), or a
+network sink. This is the **enabler** for #6, #7, #10, #11.
+
+**Effort.** Med. **Back-compat.** Full (refactor behind the existing API).
+
+**Sketch.**
+
+```
+struct sink {
+    virtual ~sink() = default;
+    virtual auto write(const record&) -> void = 0;
+    virtual auto flush() -> void = 0;
+    std::atomic<level> min_level;
+};
+```
+
+Ship `console_sink`, `file_sink`, `msvc_debug_sink` initially. `logger` holds a
+`std::vector<std::unique_ptr<sink>>`; `add_sink` / `remove_sink`. Move the current
+console+file logic into the first two sinks.
+
+## 6. Ring-buffer backtrace (dump-on-error)
+
+**What.** Keep the last N `debug`-level records in an in-memory ring buffer,
+normally discarded; on an `error`/`fatal`, flush the ring to the sinks first.
+
+**Why.** Best feature spdlog has for shipping builds: no debug spam in normal
+operation, but full context preserved when something actually breaks.
+
+**Effort.** Med. **Back-compat.** Full (additive `enable_backtrace(n)` /
+`dump_backtrace()`).
+
+**Sketch.** Fixed-size ring of pre-formatted records guarded by the mutex (or its
+own lock). On a triggering level, emit the ring in order then the triggering line.
+Cleaner once #5 exists (dump targets the sink list).
+
+## 7. Log rotation / retention
+
+**What.** Stop wiping history; roll files by size or date and keep the last N.
+
+**Why.** File opens with `std::ios::trunc` ([Log.cpp:45](../Engine/Engine/Import/Log.cpp)),
+so every run destroys the previous log — bad for diagnosing a crash after the fact.
+
+**Effort.** Med. **Back-compat.** Full (internal to the file sink).
+
+**Sketch.** As a `rotating_file_sink` (rides on #5): on open, rename
+`log.txt -> log.1.txt -> log.2.txt ...` up to N, or timestamp the filename per run.
+Optional size cap that rolls mid-run.
+
+## 8. Compile-time stripping in release
+
+**What.** A path where sub-threshold `debug`/`trace` calls compile to nothing, so
+arguments aren't even evaluated.
+
+**Why.** Even with #1, `std::make_format_args(args...)` still evaluates every
+argument on a filtered call. Truly zero-cost debug logging needs the call elided
+at compile time.
+
+**Effort.** Med, plus **aesthetic tension**: the only robust way is a macro
+(`if constexpr` can skip the body but not argument evaluation at the call site).
+Conflicts with the codebase's macro-averse style — decide whether the perf is
+worth a `GSE_LOG_DEBUG(...)`-style entry point that compiles out below a
+`compile_time_min_level` constant. **Lower priority because #1 already removes the
+runtime cost for most cases.**
+
+**Back-compat.** Introduces a new optional call form; existing calls keep working.
+
+## 9. `fatal` level + Assert integration
+
+**What.** A level above `error` that flushes everything, logs, then breaks/aborts.
+Wire it into the existing [Assert.cppm](../Engine/Engine/Import/Assert.cppm).
+
+**Why.** `error` is currently the ceiling; there's no log level that participates
+in a hard stop, and asserts/log are separate paths.
+
+**Effort.** Low–Med. **Back-compat.** Additive (new enum value — the reflection
+formatters pick up the string automatically; audit any exhaustive `switch` on
+`level`, though there are essentially none today).
+
+**Sketch.** Add `fatal` to `level`; `should_flush` returns true for it; after
+writing, `std::abort()` / `__debugbreak()` (debug). Have the assert macro route
+its message through `log::println(level::fatal, ...)`.
+
+## 10. Color console output by level
+
+**What.** ANSI color per level on the console sink (red error, yellow warning,
+etc.); plain text to the file.
+
+**Why.** Cheap dev-experience win; console is currently uncolored plain text.
+
+**Effort.** Low. **Back-compat.** Full.
+
+**Sketch.** Color belongs in the console sink (#5). Enable VT processing on the
+Windows console once at startup (`SetConsoleMode` +
+`ENABLE_VIRTUAL_TERMINAL_PROCESSING`). Gate on `isatty` / a config flag so piped
+output stays clean.
+
+## 11. Configurable pattern + structured/JSON sink
+
+**What.** A per-sink pattern string (e.g. `%t [%l][%c] %v`) instead of the
+hardcoded layout, and an optional JSON-lines sink for machine parsing.
+
+**Why.** Format is hardcoded in `write_line`. A JSON sink makes logs ingestible by
+tooling. Lower near-term value for a solo engine, hence the rank.
+
+**Effort.** Med. **Back-compat.** Full. **Depends on** #5.
+
+## 12. Scoped / thread-local context
+
+**What.** A scoped guard that attaches contextual fields (frame number, system
+name, entity id) to every line emitted within its scope, instead of threading them
+through each call.
+
+**Why.** Removes repetitive context-passing and makes per-frame/per-system logs
+correlatable.
+
+**Effort.** Med. **Back-compat.** Additive.
+
+**Sketch.** `thread_local` stack of small key/value frames; a RAII
+`log::scope("frame", n)` pushes/pops; `write_line` appends the current stack to
+the prefix. Composes with #4 (both are thread-local context).
+
+## 13. Static-destruction safety
+
+**What.** Guard against logging after the function-local `static logger`
+(`instance()`, [Log.cpp:101](../Engine/Engine/Import/Log.cpp)) is destroyed.
+
+**Why.** Any `log::println` from a static destructor running after `s_logger` is
+torn down is UB. Low probability today, but a real footgun.
+
+**Effort.** Low. **Back-compat.** Full.
+
+**Sketch.** A `std::atomic<bool> g_alive` flag set false in `~logger`; `write_line`
+falls back to a direct `cerr` write (or no-ops) when not alive. Or adopt a
+leak-on-exit strategy (never destroy the singleton) and just flush at exit.

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -73,7 +73,26 @@ Date drafted: 2026-06-19.
   gives full recent context on the way down. `Assert` routes `assert_fail` through
   `log::println(fatal, …)` (now `[[noreturn]]`), inheriting the ring dump for free.
   Uncommitted.
-- **Next ranked:** #7 rotation, #10 color, #13 static-dtor safety, #2 auto-dedup.
+- **#7 Log rotation** — done. `file_sink` rotates on open (keeps the last N runs:
+  `log.txt` + `log.1.txt`..`log.{N-1}.txt`, default N=5 via `log_files_kept`) instead
+  of truncating each run, so prior runs survive for post-crash diagnosis. Per-run
+  rotation; size-based rolling within a single long run is a separate follow-up.
+  Uncommitted.
+- **#10 Color output** — done. `console_sink` wraps each line in an ANSI SGR color
+  by level; the color is an **annotation on the `level` enum** (`[[= ansi_sgr{N} ]]`)
+  read back via reflection (`level_sgr` → `first_annotation_of_type` + `constant_of`),
+  not a hand-written switch. `set_color(bool)` toggles it (default on). The SGR code is
+  an `int` (structural) because `std::string_view` can't be an annotation value.
+- **#13 Static-destruction safety** — done. The logger is a plain global now, so a log
+  during static teardown would hit a destroyed object. A trivially-destructed
+  `logger_alive` atomic (true at end of ctor, false at start of dtor) guards the free
+  `write_line`/`flush`; when dead, `write_line` falls back to `fputs(stderr)`. Also
+  covers use-before-construction.
+- **#2 Auto-dedup** — done. `dispatch` collapses consecutive identical records (same
+  level/category/message) into "(previous message repeated N times)", flushed when a
+  different record arrives or on shutdown. The ring dump and fatal force-write bypass it.
+- **Next ranked:** #8 compile-time stripping, #11 pattern/JSON sink, #12 scoped
+  context (task-origin labeling).
 
 Everything below is the original plan, unchanged.
 

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -59,8 +59,16 @@ Date drafted: 2026-06-19.
   moved out of the interface into `Log.cpp` behind a non-template `write_line` seam,
   so the ~68 importers no longer parse the logger's internals (build-time win) and
   moodycamel stays fully contained in the `.cpp` — no PIMPL needed.
-- **Next ranked:** #6 ring-buffer backtrace, #7 rotation, then the small wins
-  (#9 fatal, #10 color, #13 static-dtor safety) and #2's auto-dedup.
+- **#6 Ring-buffer backtrace** — done. `enable_backtrace(n)` keeps the last N
+  *sub-threshold* records (the ones the filter would normally drop) in an in-memory
+  ring; on a passing `error`, the ring is force-dumped to all sinks (bracketed,
+  bypassing per-sink levels) right before the error, then cleared. `dump_backtrace()`
+  and `disable_backtrace()` for manual control. The template gate passes sub-threshold
+  records through only when backtrace is active; `write_line` / `run` funnel through a
+  new `process()` (ring the `!pass` records, dispatch the `pass` ones). Uncommitted,
+  unbuilt.
+- **Next ranked:** #7 rotation, then the small wins (#9 fatal, #10 color,
+  #13 static-dtor safety) and #2's auto-dedup.
 
 Everything below is the original plan, unchanged.
 

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -41,8 +41,26 @@ Date drafted: 2026-06-19.
   the gcc-trunk CI; trivial `#ifdef _WIN32` add later). Formatting centralized in
   `format_line`; the message is now built once as a string — the hook #2-dedup
   and #6 ring-buffer both need.
-- **#3 Async** — next, and now cleaner: the background thread just writes to the
-  sink list instead of cout/file directly.
+- **#3 Async logging** — done, opt-in, lock-free hot path. `set_async(true)` starts
+  one background thread that drains the queue and performs all sink writes; producers
+  only enqueue a pre-formatted `queued_record` and never touch I/O. Queue is
+  `moodycamel::ConcurrentQueue` + a `std::counting_semaphore` for consumer blocking
+  (only `concurrentqueue.h` is vendored, so the blocking wait is hand-rolled). The
+  hot path is lock-free (enqueue + `release`); `m_sink_mutex` only guards the actual
+  writes (consumer-only) and `add_sink`; flush coordination uses a separate
+  `m_flush_mutex` off the hot path. `flush()` posts a flush control message and waits
+  a token barrier; a `terminate` message + drain handles stop. Default stays
+  synchronous. Trade-offs vs a locked queue: the on/off toggle isn't fully race-free
+  (no lock pairs the `m_async` flip with enqueues — toggle at quiescent points;
+  stragglers are caught by the stop/dtor drain), and `flush()` is a strong *practical*
+  barrier rather than a strict global one (moodycamel has no cross-producer FIFO).
+  Uncommitted pending a build/test.
+- **Architecture (interface slimming):** `logger` / `queued_record` / `instance()`
+  moved out of the interface into `Log.cpp` behind a non-template `write_line` seam,
+  so the ~68 importers no longer parse the logger's internals (build-time win) and
+  moodycamel stays fully contained in the `.cpp` — no PIMPL needed.
+- **Next ranked:** #6 ring-buffer backtrace, #7 rotation, then the small wins
+  (#9 fatal, #10 color, #13 static-dtor safety) and #2's auto-dedup.
 
 Everything below is the original plan, unchanged.
 

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -91,8 +91,21 @@ Date drafted: 2026-06-19.
 - **#2 Auto-dedup** — done. `dispatch` collapses consecutive identical records (same
   level/category/message) into "(previous message repeated N times)", flushed when a
   different record arrives or on shutdown. The ring dump and fatal force-write bypass it.
-- **Next ranked:** #8 compile-time stripping, #11 pattern/JSON sink, #12 scoped
-  context (task-origin labeling).
+- **#11 JSON sink** — done. `log::json_sink` (exported, opt-in via `add_sink`) writes
+  JSON-lines with escaped fields. The sink interface already supported per-sink
+  formatting; this is the concrete alternate format (no pattern-string parser — the
+  sink's `write()` is the formatting hook).
+- **#12 scoped context** — done. RAII `log::scope(label)` pushes onto a thread-local
+  context captured in `write_line` *on the producer* (so it's async-correct) and
+  prepended to each line's prefix. Task-origin labeling (source_location at `post()`)
+  deliberately not pursued — bigger scheduler change for low value.
+- **#8 compile-time stripping** — NOT done (deliberate). True stripping must skip
+  argument *evaluation* at the call site, which only a macro can do, and macros don't
+  export across module boundaries — it would need a separate non-module header. Lowest
+  value; the runtime per-category gate already covers the common case.
+
+**Backlog complete.** The only not-always-on features are opt-in tools used at call
+sites as needed — `sampler`, `json_sink`, `scope`. Everything else is wired/active.
 
 Everything below is the original plan, unchanged.
 

--- a/docs/logger_improvements_plan.md
+++ b/docs/logger_improvements_plan.md
@@ -67,8 +67,13 @@ Date drafted: 2026-06-19.
   records through only when backtrace is active; `write_line` / `run` funnel through a
   new `process()` (ring the `!pass` records, dispatch the `pass` ones). Uncommitted,
   unbuilt.
-- **Next ranked:** #7 rotation, then the small wins (#9 fatal, #10 color,
-  #13 static-dtor safety) and #2's auto-dedup.
+- **#9 `fatal` level + Assert** — done. `fatal` is the new top level; `write_line`
+  handles it specially: flush (drains the async queue), dump the backtrace ring,
+  force-write the fatal line to every sink, flush, `std::terminate()`. A fatal log
+  gives full recent context on the way down. `Assert` routes `assert_fail` through
+  `log::println(fatal, …)` (now `[[noreturn]]`), inheriting the ring dump for free.
+  Uncommitted.
+- **Next ranked:** #7 rotation, #10 color, #13 static-dtor safety, #2 auto-dedup.
 
 Everything below is the original plan, unchanged.
 


### PR DESCRIPTION
## Summary

Overhauls `gse.log` from a basic synchronous logger into a production-grade one, plus the dependency/interface cleanups that fell out of it. Branched off `dev`; 11 commits.

## What changed

**Logging features**
- Per-category runtime level filtering (`set_level`) — atomic, lock-free read on the hot path.
- Opt-in throttling: `log::sampler` (every-N / every-T).
- Async logging: lock-free `moodycamel::ConcurrentQueue` + a background consumer; producers only enqueue. `flush()` is a hard barrier; errors flush promptly.
- Named threads via a reflected `thread_role` enum (main / worker-N / watchdog / capture / network).
- Sink abstraction (`sink` interface): console + file built in, plus an opt-in `json_sink` (JSON-lines).
- Ring-buffer backtrace: sub-threshold (`debug`) records held in a ring and force-dumped before any error/fatal.
- Log rotation: keep the last N runs instead of truncating each run.
- `fatal` level: dumps the ring + flushes + terminates; `Assert` routes through it.
- ANSI color by level, driven by an `[[= ansi_sgr{...} ]]` annotation on the `level` enum read via reflection (no hand-written switch).
- Consecutive-duplicate collapsing ("(previous message repeated N times)").
- `log::scope(label)` RAII thread-local context, captured producer-side (async-correct).
- Static-destruction guard for the now-global logger.

**Architecture / cleanup**
- Moved `logger`/`queued_record`/`instance` out of the `gse.log` interface behind a non-template `write_line` seam, so importers stop parsing the logger internals and moodycamel stays contained in the `.cpp`.
- Replaced the `instance()` Meyers singleton with a plain module global; dropped `g_` prefixes.
- Gave `gse.assert` the same treatment: interface now imports only `std`, impl in a new `Assert.cpp`; carried over `capture_stacktrace(2)` from the locomotion branch.
- Converted the `id_registry()` singleton to inline module globals.

**Runtime wiring (bootstrap)**
- Filter set to `info`; backtrace ring enabled (256-deep); async turned on after init and off before shutdown; watchdog/capture/network threads named at their spawn sites.

See `docs/logger_improvements_plan.md` for the full ranked backlog and status.
